### PR TITLE
Connector API refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.czertainly</groupId>
             <artifactId>interfaces</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- Spring  -->

--- a/src/main/java/com/czertainly/core/api/web/ConnectorControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/ConnectorControllerImpl.java
@@ -1,6 +1,5 @@
 package com.czertainly.core.api.web;
 
-import java.net.ConnectException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +7,8 @@ import java.util.Map;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.model.AttributeCallback;
 import com.czertainly.api.model.HealthDto;
-import com.czertainly.api.model.connector.ForceDeleteMessageDto;
+import com.czertainly.api.model.UuidDto;
+import com.czertainly.api.model.connector.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,9 +23,6 @@ import com.czertainly.api.exception.AlreadyExistException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.AttributeDefinition;
-import com.czertainly.api.model.connector.ConnectDto;
-import com.czertainly.api.model.connector.ConnectorDto;
-import com.czertainly.api.model.connector.FunctionGroupCode;
 
 @RestController
 public class ConnectorControllerImpl implements ConnectorController {
@@ -67,19 +64,20 @@ public class ConnectorControllerImpl implements ConnectorController {
     }
 
     @Override
-    public ResponseEntity<?> createConnector(@RequestBody ConnectorDto request)
-            throws AlreadyExistException, NotFoundException {
+    public ResponseEntity<UuidDto> createConnector(@RequestBody ConnectorRequestDto request)
+            throws AlreadyExistException, ConnectorException {
         ConnectorDto connectorDto = connectorService.createConnector(request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{uuid}")
                 .buildAndExpand(connectorDto.getUuid()).toUri();
-
-        return ResponseEntity.created(location).build();
+        UuidDto dto = new UuidDto();
+        dto.setUuid(connectorDto.getUuid());
+        return ResponseEntity.created(location).body(dto);
     }
 
     @Override
-    public ConnectorDto updateConnector(@PathVariable String uuid, @RequestBody ConnectorDto request)
-            throws NotFoundException {
+    public ConnectorDto updateConnector(@PathVariable String uuid, @RequestBody ConnectorRequestDto request)
+            throws ConnectorException {
         return connectorService.updateConnector(uuid, request);
     }
 

--- a/src/main/java/com/czertainly/core/api/web/ConnectorControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/ConnectorControllerImpl.java
@@ -64,7 +64,7 @@ public class ConnectorControllerImpl implements ConnectorController {
     }
 
     @Override
-    public ResponseEntity<UuidDto> createConnector(@RequestBody ConnectorRequestDto request)
+    public ResponseEntity<?> createConnector(@RequestBody ConnectorRequestDto request)
             throws AlreadyExistException, ConnectorException {
         ConnectorDto connectorDto = connectorService.createConnector(request);
 

--- a/src/main/java/com/czertainly/core/dao/entity/Connector.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Connector.java
@@ -134,7 +134,6 @@ public class Connector extends Audited implements Serializable, DtoMapper<Connec
     @Override
     public ConnectorDto mapToDto() {
         ConnectorDto dto = new ConnectorDto();
-        dto.setId(this.id);
         dto.setUuid(this.uuid);
         dto.setName(this.name);
         dto.setUrl(this.url);

--- a/src/main/java/com/czertainly/core/dao/entity/Endpoint.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Endpoint.java
@@ -37,7 +37,6 @@ public class Endpoint extends UniquelyIdentified implements Serializable, DtoMap
     @Override
     public EndpointDto mapToDto() {
         EndpointDto dto = new EndpointDto();
-        dto.setId(this.id);
         dto.setUuid(this.uuid);
         dto.setName(this.name);
         dto.setContext(this.context);

--- a/src/main/java/com/czertainly/core/dao/entity/FunctionGroup.java
+++ b/src/main/java/com/czertainly/core/dao/entity/FunctionGroup.java
@@ -82,7 +82,6 @@ public class FunctionGroup extends UniquelyIdentified implements Serializable, D
     @Override
     public FunctionGroupDto mapToDto() {
         FunctionGroupDto dto = new FunctionGroupDto();
-        dto.setId(this.id);
         dto.setUuid(this.uuid);
         dto.setName(this.name);
         dto.setFunctionGroupCode(this.code);

--- a/src/main/java/com/czertainly/core/service/ConnectorService.java
+++ b/src/main/java/com/czertainly/core/service/ConnectorService.java
@@ -25,11 +25,11 @@ public interface ConnectorService {
 
     Connector getConnectorEntity(String uuid) throws NotFoundException;
 
-    ConnectorDto createConnector(ConnectorDto request) throws AlreadyExistException, NotFoundException;
+    ConnectorDto createConnector(ConnectorRequestDto request) throws AlreadyExistException, ConnectorException;
 
     ConnectorDto createConnector(ConnectorDto request, ConnectorStatus connectorStatus) throws NotFoundException, AlreadyExistException;
 
-    ConnectorDto updateConnector(String uuid, ConnectorDto request) throws NotFoundException;
+    ConnectorDto updateConnector(String uuid, ConnectorRequestDto request) throws ConnectorException;
 
     void removeConnector(String uuid) throws NotFoundException;
 

--- a/src/main/java/com/czertainly/core/service/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ConnectorServiceImpl.java
@@ -119,6 +119,8 @@ public class ConnectorServiceImpl implements ConnectorService {
                     }
                 }
             }
+            connector.setStatus(ConnectorStatus.CONNECTED);
+            connectorRepository.save(connector);
         } catch (ConnectorCommunicationException e) {
             connector.setStatus(ConnectorStatus.OFFLINE);
             connectorRepository.save(connector);

--- a/src/main/java/com/czertainly/core/service/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ConnectorServiceImpl.java
@@ -235,8 +235,8 @@ public class ConnectorServiceImpl implements ConnectorService {
     private Set<Connector2FunctionGroup> setFunctionGroups(List<FunctionGroupDto> functionGroups, Connector connector) throws NotFoundException {
         // adding phase
         for (FunctionGroupDto dto : functionGroups) {
-            FunctionGroup functionGroup = functionGroupRepository.findById(dto.getId())
-                    .orElseThrow(() -> new NotFoundException(FunctionGroup.class, dto.getId()));
+            FunctionGroup functionGroup = functionGroupRepository.findByUuid(dto.getUuid())
+                    .orElseThrow(() -> new NotFoundException(FunctionGroup.class, dto.getUuid()));
 
             Optional<Connector2FunctionGroup> c2fg = connector2FunctionGroupRepository.findByConnectorAndFunctionGroup(connector, functionGroup);
 

--- a/src/main/java/com/czertainly/core/service/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ConnectorServiceImpl.java
@@ -370,8 +370,8 @@ public class ConnectorServiceImpl implements ConnectorService {
             ConnectDto response = new ConnectDto();
             FunctionGroupDto functionGroupDto = functionGroup.get().mapToDto();
             functionGroupDto.setKinds(f.getKinds());
+            functionGroupDto.setEndPoints(f.getEndPoints());
             response.setFunctionGroup(functionGroupDto);
-            response.setEndpoints(f.getEndPoints());
             responses.add(response);
         }
 
@@ -445,8 +445,8 @@ public class ConnectorServiceImpl implements ConnectorService {
             ConnectDto response = new ConnectDto();
             FunctionGroupDto functionGroupDto = functionGroup.get().mapToDto();
             functionGroupDto.setKinds(f.getKinds());
+            functionGroupDto.setEndPoints(f.getEndPoints());
             response.setFunctionGroup(functionGroupDto);
-            response.setEndpoints(f.getEndPoints());
             responses.add(response);
         }
 

--- a/src/test/java/com/czertainly/core/service/ConnectorServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/ConnectorServiceTest.java
@@ -8,6 +8,7 @@ import com.czertainly.api.model.AttributeDefinition;
 import com.czertainly.api.model.HealthDto;
 import com.czertainly.api.model.HealthStatus;
 import com.czertainly.api.model.connector.ConnectorDto;
+import com.czertainly.api.model.connector.ConnectorRequestDto;
 import com.czertainly.api.model.connector.ConnectorStatus;
 import com.czertainly.api.model.connector.FunctionGroupCode;
 import com.czertainly.core.dao.entity.Connector;
@@ -171,9 +172,13 @@ public class ConnectorServiceTest {
 
     @Test
     public void testAddConnector() throws ConnectorException, AlreadyExistException {
-        ConnectorDto request = new ConnectorDto();
+        mockServer.stubFor(WireMock
+                .get("/v1")
+                .willReturn(WireMock.okJson("[]")));
+
+        ConnectorRequestDto request = new ConnectorRequestDto();
         request.setName("testConnector2");
-        request.setFunctionGroups(List.of());
+        request.setUrl("http://localhost:3665");
 
         ConnectorDto dto = connectorService.createConnector(request);
         Assertions.assertNotNull(dto);
@@ -182,24 +187,26 @@ public class ConnectorServiceTest {
 
     @Test
     public void testAddConnector_validationFail() {
-        ConnectorDto request = new ConnectorDto();
+        ConnectorRequestDto request = new ConnectorRequestDto();
         Assertions.assertThrows(ValidationException.class, () -> connectorService.createConnector(request));
     }
 
     @Test
     public void testAddConnector_alreadyExist() {
-        ConnectorDto request = new ConnectorDto();
-        request.setName(CONNECTOR_NAME); // connector with same name exist
-        request.setFunctionGroups(List.of());
-
+        ConnectorRequestDto request = new ConnectorRequestDto();
+        request.setName(CONNECTOR_NAME);
         Assertions.assertThrows(AlreadyExistException.class, () -> connectorService.createConnector(request));
     }
 
     @Test
     public void testEditConnector() throws ConnectorException {
-        ConnectorDto request = new ConnectorDto();
-        request.setName(connector.getName());
-        request.setFunctionGroups(List.of());
+        mockServer.stubFor(WireMock
+                .get("/v1")
+                .willReturn(WireMock.okJson("[]")));
+
+        ConnectorRequestDto request = new ConnectorRequestDto();
+        request.setName("testConnector2");
+        request.setUrl("http://localhost:3665");
 
         ConnectorDto dto = connectorService.updateConnector(connector.getUuid(), request);
         Assertions.assertNotNull(dto);


### PR DESCRIPTION
This pull request contains the following changes:

- Remove duplicated items from the connect API response
- Create separate DTO for creating and updating connector
- Update test cases based on the new creation logic
- Return UUID of the connector when creating a new object