### PR TITLE
Fix parsing of the Base64 encoded data for client operations

### DIFF
--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -31,10 +31,8 @@ import com.czertainly.core.service.CertificateEventHistoryService;
 import com.czertainly.core.service.CertificateService;
 import com.czertainly.core.service.v2.ClientOperationService;
 import com.czertainly.core.service.v2.ExtendedAttributeService;
-import com.czertainly.core.util.AttributeDefinitionUtils;
-import com.czertainly.core.util.CertificateUtil;
-import com.czertainly.core.util.MetaDefinitions;
-import com.czertainly.core.util.ValidatorUtil;
+import com.czertainly.core.util.*;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +40,9 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.io.IOException;
 import java.security.cert.CertificateException;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 
@@ -98,7 +98,13 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         extendedAttributeService.validateLegacyConnector(raProfile.getAuthorityInstanceReference().getConnector());
 
         CertificateSignRequestDto caRequest = new CertificateSignRequestDto();
-        caRequest.setPkcs10(request.getPkcs10());
+        // the CSR should be properly converted to ensure consistent Base64-encoded format
+        try {
+            caRequest.setPkcs10(Base64.getEncoder().encodeToString(parseCsrToJcaObject(request.getPkcs10()).getEncoded()));
+        } catch (IOException e) {
+            logger.debug("Failed to parse CSR: " + e);
+            throw new CertificateException(e);
+        }
         caRequest.setAttributes(request.getAttributes());
         caRequest.setRaProfileAttributes(AttributeDefinitionUtils.getClientAttributes(raProfile.mapToDto().getAttributes()));
 
@@ -141,7 +147,13 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         extendedAttributeService.validateLegacyConnector(raProfile.getAuthorityInstanceReference().getConnector());
         logger.debug("Renewing Certificate: ", oldCertificate.toString());
         CertificateRenewRequestDto caRequest = new CertificateRenewRequestDto();
-        caRequest.setPkcs10(request.getPkcs10());
+        // the CSR should be properly converted to ensure consistent Base64-encoded format
+        try {
+            caRequest.setPkcs10(Base64.getEncoder().encodeToString(parseCsrToJcaObject(request.getPkcs10()).getEncoded()));
+        } catch (IOException e) {
+            logger.debug("Failed to parse CSR: " + e);
+            throw new CertificateException(e);
+        }
         caRequest.setRaProfileAttributes(AttributeDefinitionUtils.getClientAttributes(raProfile.mapToDto().getAttributes()));
         caRequest.setCertificate(oldCertificate.getCertificateContent().getContent());
         caRequest.setMeta(oldCertificate.getMeta());
@@ -235,5 +247,17 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         }catch(Exception e) {
             logger.warn(e.getMessage());
         }
+    }
+
+    private JcaPKCS10CertificationRequest parseCsrToJcaObject(String pkcs10) throws IOException {
+        JcaPKCS10CertificationRequest csr;
+        try {
+            csr = CsrUtil.csrStringToJcaObject(pkcs10);
+        } catch (IOException e) {
+            logger.debug("Failed to parse CSR, will decode and try again...");
+            String decodedPkcs10 = new String(Base64.getDecoder().decode(pkcs10));
+            csr = CsrUtil.csrStringToJcaObject(decodedPkcs10);
+        }
+        return csr;
     }
 }

--- a/src/main/java/com/czertainly/core/util/CsrUtil.java
+++ b/src/main/java/com/czertainly/core/util/CsrUtil.java
@@ -1,0 +1,21 @@
+package com.czertainly.core.util;
+
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Base64;
+
+public class CsrUtil {
+    private static final Logger logger = LoggerFactory.getLogger(CsrUtil.class);
+
+    public static JcaPKCS10CertificationRequest csrStringToJcaObject(String csr) throws IOException {
+        csr = csr.replace("-----BEGIN CERTIFICATE REQUEST-----", "")
+                .replaceAll(System.lineSeparator(), "")
+                .replace("-----END CERTIFICATE REQUEST-----", "");
+        logger.debug("Decoding Base64-encoded CSR: " + csr);
+        byte[] decoded = Base64.getDecoder().decode(csr);
+        return new JcaPKCS10CertificationRequest(decoded);
+    }
+}


### PR DESCRIPTION
- get the JcaPKCS10CertificationRequest object
- ensure consistency of the output

Fix #61 