### PR TITLE
Update certificate group update

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -186,7 +186,7 @@ public class CertificateServiceImpl implements CertificateService {
         CertificateGroup certificateGroup = groupRepository.findByUuid(request.getGroupUuid())
                 .orElseThrow(() -> new NotFoundException(CertificateGroup.class, request.getGroupUuid()));
         String originalGroup = "undefined";
-        if (certificate.getOwner() != null) {
+        if (certificate.getGroup() != null) {
             originalGroup = certificate.getGroup().getName();
         }
         certificate.setGroup(certificateGroup);


### PR DESCRIPTION
Details: Unable to update the group of a certificate when the owner of the certificate is not empty.

Root Cause: In the core, the code is performing

(certificate.getOwner() != null)
instead of
(certificate.getGroup() != null)

closes #68 