### PR TITLE
Fix deletion of discovered certificates

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -150,12 +150,16 @@ public class CertificateServiceImpl implements CertificateService {
         if (!errors.isEmpty()) {
             throw new ValidationException("Could not delete certificate", errors);
         }
+
         if (discoveryCertificateRepository.findByCertificateContent(certificate.getCertificateContent()).isEmpty()) {
             CertificateContent content = certificateContentRepository
                     .findById(certificate.getCertificateContent().getId()).orElse(null);
             if (content != null) {
+                certificateRepository.delete(certificate);
                 certificateContentRepository.delete(content);
             }
+        } else {
+            certificateRepository.delete(certificate);
         }
 
         certificateRepository.delete(certificate);

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -161,8 +161,6 @@ public class CertificateServiceImpl implements CertificateService {
         } else {
             certificateRepository.delete(certificate);
         }
-
-        certificateRepository.delete(certificate);
     }
 
     @Override


### PR DESCRIPTION
**Issue:** When attempting to delete a certificate that is discovered, there is an exception that the code is trying to delete the entry from the certificate content table before deleting it in the certificate table.

**Fix:** Added logic to handle the scenario. If the certificate is found to be discovered and if the discovery part of the certificate still exists, then delete only the content.. Else the code will delete the certificate table entry and then delete the certificate content since the certificate table references the contents

closes #79 