### PR TITLE
Fix Renew issue and delete certificate Authority issues

### DIFF
--- a/src/main/java/com/czertainly/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/czertainly/core/api/ExceptionHandlingAdvice.java
@@ -241,6 +241,20 @@ public class ExceptionHandlingAdvice {
     }
 
     /**
+     * Handler for {@link CertificateOperationException}.
+     *
+     * @return
+     */
+    @ExceptionHandler(CertificateOperationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorMessageDto handleCertificateOperationException(CertificateOperationException ex) {
+        LOG.info("HTTP 400: {}", ex.getMessage());
+        return ErrorMessageDto.getInstance(ex.getMessage());
+    }
+
+
+
+    /**
      * Handler for {@link Exception}.
      *
      * @return

--- a/src/main/java/com/czertainly/core/api/v2/client/ClientOperationControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/v2/client/ClientOperationControllerImpl.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.api.v2.client;
 
 import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.CertificateOperationException;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
@@ -52,7 +53,7 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     public ClientCertificateDataResponseDto renewCertificate(
             @PathVariable String raProfileUuid,
             @PathVariable String certificateUuid,
-            @RequestBody ClientCertificateRenewRequestDto request) throws NotFoundException, ConnectorException, AlreadyExistException, CertificateException {
+            @RequestBody ClientCertificateRenewRequestDto request) throws NotFoundException, ConnectorException, AlreadyExistException, CertificateException, CertificateOperationException {
         return clientOperationService.renewCertificate(raProfileUuid, certificateUuid, request, false);
     }
 

--- a/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -84,7 +84,7 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
         authorityInstanceDto.setKind(authorityInstanceReference.getKind());
         if (authorityInstanceReference.getConnector() == null) {
             authorityInstanceDto.setConnectorName(authorityInstanceReference.getConnectorName() + " (Deleted)");
-            authorityInstanceDto.setConnectorUuid("Connector not found");
+            authorityInstanceDto.setConnectorUuid("");
             logger.warn("Connector associated with the Authority: {} is not found. Unable to show details", authorityInstanceReference);
             return authorityInstanceDto;
         }

--- a/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -78,21 +78,24 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
         AuthorityInstanceReference authorityInstanceReference = authorityInstanceReferenceRepository.findByUuid(uuid)
                 .orElseThrow(() -> new NotFoundException(AuthorityInstanceReference.class, uuid));
 
+        AuthorityInstanceDto authorityInstanceDto = new AuthorityInstanceDto();
+        authorityInstanceDto.setName(authorityInstanceReference.getName());
+        authorityInstanceDto.setUuid(authorityInstanceReference.getUuid());
+        authorityInstanceDto.setKind(authorityInstanceReference.getKind());
         if (authorityInstanceReference.getConnector() == null) {
-            throw new NotFoundException("Connector associated with the Authority is not found. Unable to show details");
+            authorityInstanceDto.setConnectorName(authorityInstanceReference.getConnectorName() + " (Deleted)");
+            authorityInstanceDto.setConnectorUuid("Connector not found");
+            logger.warn("Connector associated with the Authority: {} is not found. Unable to show details", authorityInstanceReference);
+            return authorityInstanceDto;
         }
 
         AuthorityProviderInstanceDto authorityProviderInstanceDto = authorityInstanceApiClient.getAuthorityInstance(authorityInstanceReference.getConnector().mapToDto(),
                 authorityInstanceReference.getAuthorityInstanceUuid());
 
-        AuthorityInstanceDto authorityInstanceDto = new AuthorityInstanceDto();
         authorityInstanceDto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(authorityProviderInstanceDto.getAttributes()));
         authorityInstanceDto.setName(authorityProviderInstanceDto.getName());
-        authorityInstanceDto.setUuid(authorityInstanceReference.getUuid());
+        authorityInstanceDto.setConnectorName(authorityInstanceReference.getConnector().getName());
         authorityInstanceDto.setConnectorUuid(authorityInstanceReference.getConnector().getUuid());
-        authorityInstanceDto.setKind(authorityInstanceReference.getKind());
-        authorityInstanceDto.setConnectorName(authorityInstanceReference.getConnectorName());
-
         return authorityInstanceDto;
     }
 
@@ -173,19 +176,22 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
     public void removeAuthorityInstance(String uuid) throws NotFoundException, ConnectorException {
         AuthorityInstanceReference authorityInstanceRef = authorityInstanceReferenceRepository.findByUuid(uuid)
                 .orElseThrow(() -> new NotFoundException(AuthorityInstanceReference.class, uuid));
+        if(authorityInstanceRef.getConnector() != null) {
+            List<ValidationError> errors = new ArrayList<>();
+            if (!authorityInstanceRef.getRaProfiles().isEmpty()) {
+                errors.add(ValidationError.create("Authority instance {} has {} dependent RA profiles", authorityInstanceRef.getName(),
+                        authorityInstanceRef.getRaProfiles().size()));
+                authorityInstanceRef.getRaProfiles().stream().forEach(c -> errors.add(ValidationError.create(c.getName())));
+            }
 
-        List<ValidationError> errors = new ArrayList<>();
-        if (!authorityInstanceRef.getRaProfiles().isEmpty()) {
-            errors.add(ValidationError.create("Authority instance {} has {} dependent RA profiles", authorityInstanceRef.getName(),
-                    authorityInstanceRef.getRaProfiles().size()));
-            authorityInstanceRef.getRaProfiles().stream().forEach(c -> errors.add(ValidationError.create(c.getName())));
+            if (!errors.isEmpty()) {
+                throw new ValidationException("Could not delete Authority instance", errors);
+            }
+
+            authorityInstanceApiClient.removeAuthorityInstance(authorityInstanceRef.getConnector().mapToDto(), authorityInstanceRef.getAuthorityInstanceUuid());
+        }else{
+            logger.debug("Deleting authority without connector: {}", authorityInstanceRef);
         }
-
-        if (!errors.isEmpty()) {
-            throw new ValidationException("Could not delete Authority instance", errors);
-        }
-
-        authorityInstanceApiClient.removeAuthorityInstance(authorityInstanceRef.getConnector().mapToDto(), authorityInstanceRef.getAuthorityInstanceUuid());
 
         authorityInstanceReferenceRepository.delete(authorityInstanceRef);
     }
@@ -265,7 +271,9 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
             } else {
                 deletableCredentials.add(authorityInstanceRef);
                 try {
-                    authorityInstanceApiClient.removeAuthorityInstance(authorityInstanceRef.getConnector().mapToDto(), authorityInstanceRef.getAuthorityInstanceUuid());
+                    if(authorityInstanceRef.getConnector() != null) {
+                        authorityInstanceApiClient.removeAuthorityInstance(authorityInstanceRef.getConnector().mapToDto(), authorityInstanceRef.getAuthorityInstanceUuid());
+                    }
                 }catch(ConnectorException e){
                     logger.error("Unable to delete authority with name {}", authorityInstanceRef.getName());
                 }
@@ -291,7 +299,9 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
                     raProfileRepository.save(ref);
                 }
             }
+            if(authorityInstanceRef.getConnector() != null) {
                 authorityInstanceApiClient.removeAuthorityInstance(authorityInstanceRef.getConnector().mapToDto(), authorityInstanceRef.getAuthorityInstanceUuid());
+            }
             authorityInstanceReferenceRepository.delete(authorityInstanceRef);
         }catch (ConnectorException e){
                 logger.warn("Unable to delete the Authority instance with uuid {}. It may have been deleted", uuid);

--- a/src/main/java/com/czertainly/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/LocationServiceImpl.java
@@ -4,6 +4,7 @@ import com.czertainly.api.clients.EntityInstanceApiClient;
 import com.czertainly.api.clients.LocationApiClient;
 import com.czertainly.api.exception.AlreadyExistException;
 import com.czertainly.api.exception.CertificateException;
+import com.czertainly.api.exception.CertificateOperationException;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.LocationException;
 import com.czertainly.api.exception.NotFoundException;
@@ -568,7 +569,7 @@ public class LocationServiceImpl implements LocationService {
                     certificateLocation.getCertificate().getUuid(),
                     clientCertificateRenewRequestDto, true
             );
-        } catch (ConnectorException | AlreadyExistException | java.security.cert.CertificateException e) {
+        } catch (ConnectorException | AlreadyExistException | java.security.cert.CertificateException | CertificateOperationException e) {
             logger.debug("Failed to renew Certificate for Location " + certificateLocation.getLocation().getName() +
                     ", " + certificateLocation.getLocation().getUuid() + ": " + e.getMessage());
             throw new LocationException("Failed to renew Certificate for Location " + certificateLocation.getLocation().getName());

--- a/src/main/java/com/czertainly/core/service/v2/ClientOperationService.java
+++ b/src/main/java/com/czertainly/core/service/v2/ClientOperationService.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.service.v2;
 
 import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.CertificateOperationException;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
@@ -30,7 +31,7 @@ public interface ClientOperationService {
     ClientCertificateDataResponseDto renewCertificate(
             String raProfileUuid,
             String certificateUuid,
-            ClientCertificateRenewRequestDto request, Boolean ignoreAuthToRa) throws NotFoundException, ConnectorException, AlreadyExistException, CertificateException;
+            ClientCertificateRenewRequestDto request, Boolean ignoreAuthToRa) throws NotFoundException, ConnectorException, AlreadyExistException, CertificateException, CertificateOperationException;
 
     List<AttributeDefinition> listRevokeCertificateAttributes(
             String raProfileUuid) throws NotFoundException, ConnectorException;

--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -199,6 +199,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
 
         HashMap<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put("CSR", pkcs10);
+        additionalInformation.put("Parent Certificate UUID", oldCertificate.getUuid());
+        additionalInformation.put("Parent Certificate Serial Number", oldCertificate.getSerialNumber());
         Certificate certificate = null;
         CertificateDataResponseDto caResponse = null;
         try {

--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -2,6 +2,7 @@ package com.czertainly.core.service.v2.impl;
 
 import com.czertainly.api.clients.v2.CertificateApiClient;
 import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.CertificateOperationException;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
@@ -172,7 +173,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
 
     @Override
     @AuditLogged(originator = ObjectType.CLIENT, affected = ObjectType.END_ENTITY_CERTIFICATE, operation = OperationType.RENEW)
-    public ClientCertificateDataResponseDto renewCertificate(String raProfileUuid, String certificateUuid, ClientCertificateRenewRequestDto request, Boolean ignoreAuthToRa) throws NotFoundException, ConnectorException, AlreadyExistException, CertificateException {
+    public ClientCertificateDataResponseDto renewCertificate(String raProfileUuid, String certificateUuid, ClientCertificateRenewRequestDto request, Boolean ignoreAuthToRa) throws NotFoundException, ConnectorException, AlreadyExistException, CertificateException, CertificateOperationException {
         RaProfile raProfile = raProfileRepository.findByUuidAndEnabledIsTrue(raProfileUuid)
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
 
@@ -231,7 +232,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         } catch (Exception e){
             certificateEventHistoryService.addEventHistory(CertificateEvent.RENEW, CertificateEventStatus.FAILED, e.getMessage(), MetaDefinitions.serialize(additionalInformation), oldCertificate);
             logger.error("Failed to renew Certificate", e.getMessage());
-            return null;
+            throw new CertificateOperationException("Failed to renew certificate: " + e.getMessage());
         }
 
         logger.info("Certificate Renewed: {}", certificate);

--- a/src/test/java/com/czertainly/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/czertainly/core/service/ClientOperationServiceV2Test.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.service;
 
 import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.CertificateOperationException;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.model.common.NameAndIdDto;
@@ -220,7 +221,7 @@ public class ClientOperationServiceV2Test {
     }
 
     @Test
-    public void testRenewCertificate() throws ConnectorException, CertificateException, AlreadyExistException {
+    public void testRenewCertificate() throws ConnectorException, CertificateException, AlreadyExistException, CertificateOperationException {
         String certificateData = Base64.getEncoder().encodeToString(x509Cert.getEncoded());
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/renew"))


### PR DESCRIPTION
Fixed the following issues.

1. Failure in renewal and returning null
2. Unable to delete the authority if the connector is deleted
3. Add Certificate Operation Exception to the client operation API
closes #94 #87 