### PR TITLE
Add kind and Name to the DTO for update authority instance

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -164,6 +164,8 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
         credentialService.loadFullCredentialData(attributes);
 
         AuthorityProviderInstanceRequestDto authorityInstanceDto = new AuthorityProviderInstanceRequestDto();
+        authorityInstanceDto.setKind(ref.getKind());
+        authorityInstanceDto.setName(ref.getName());
         authorityInstanceDto.setAttributes(AttributeDefinitionUtils.getClientAttributes(attributes));
         authorityInstanceApiClient.updateAuthorityInstance(connector.mapToDto(),
                 authorityInstanceRef.getAuthorityInstanceUuid(), authorityInstanceDto);


### PR DESCRIPTION
When calling the connector to update the authority instance, add the name and kind to the request so that connector can use the kind to validate the attributes