### PR TITLE
Update Credential attribute to set value as null

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CredentialServiceImpl.java
@@ -299,7 +299,7 @@ public class CredentialServiceImpl implements CredentialService {
     private CredentialDto maskSecret(CredentialDto credentialDto){
         for(ResponseAttributeDto responseAttributeDto: credentialDto.getAttributes()){
             if(TO_BE_MASKED.contains(responseAttributeDto.getType())){
-                responseAttributeDto.setContent(new BaseAttributeContent<String>(){{setValue("************");}});
+                responseAttributeDto.setContent(new BaseAttributeContent<String>(){{setValue(null);}});
             }
         }
         return credentialDto;

--- a/src/main/java/com/czertainly/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/LocationServiceImpl.java
@@ -814,7 +814,7 @@ public class LocationServiceImpl implements LocationService {
     private LocationDto maskSecret(LocationDto locationDto){
         for(ResponseAttributeDto responseAttributeDto: locationDto.getAttributes()){
             if(TO_BE_MASKED.contains(responseAttributeDto.getType())){
-                responseAttributeDto.setContent(new BaseAttributeContent<String>(){{setValue("************");}});
+                responseAttributeDto.setContent(new BaseAttributeContent<String>(){{setValue(null);}});
             }
         }
         return locationDto;


### PR DESCRIPTION
When sending the attribute of type secret in the API, set the value of the content as null rather than *******