### PR TITLE
Add description to compliance profile list dto

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/ComplianceProfile.java
+++ b/src/main/java/com/czertainly/core/dao/entity/ComplianceProfile.java
@@ -125,6 +125,7 @@ public class ComplianceProfile extends Audited implements Serializable, DtoMappe
         ComplianceProfilesListDto complianceProfileDto = new ComplianceProfilesListDto();
         complianceProfileDto.setName(name);
         complianceProfileDto.setUuid(uuid);
+        complianceProfileDto.setDescription(description);
 
         Map<String, Integer> providerGroupSummary = new HashMap<>();
         Map<String, Integer> providerGroupSummaryRules = new HashMap<>();
@@ -145,12 +146,18 @@ public class ComplianceProfile extends Audited implements Serializable, DtoMappe
         }
 
         Map<String, Integer> providerSummary = new HashMap<>();
-        for(ComplianceProfileRule complianceRule : complianceRules){
-            String connectorName = complianceRule.getComplianceRule().getConnector().getName();
-            if(providerSummary.containsKey(connectorName)){
-                providerSummary.put(connectorName, providerSummary.get(connectorName) + 1);
-            } else {
+        if(complianceRules != null && complianceRules.isEmpty()) {
+            for(String connectorName : providerGroupSummaryRules.keySet()) {
                 providerSummary.put(connectorName, providerGroupSummaryRules.getOrDefault(connectorName, 1));
+            }
+        } else {
+            for (ComplianceProfileRule complianceRule : complianceRules) {
+                String connectorName = complianceRule.getComplianceRule().getConnector().getName();
+                if (providerSummary.containsKey(connectorName)) {
+                    providerSummary.put(connectorName, providerSummary.get(connectorName) + 1);
+                } else {
+                    providerSummary.put(connectorName, providerGroupSummaryRules.getOrDefault(connectorName, 1));
+                }
             }
         }
 


### PR DESCRIPTION
This commits has the following fix

1. Add description to the compliance profile list dto
2. When the compliance profile has only groups and no rules, the list dto contains the wrong number