### PR TITLE
Fail certificate renewal when the certificate does not have RA Profile

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/LocationServiceImpl.java
@@ -499,6 +499,12 @@ public class LocationServiceImpl implements LocationService {
             throw new LocationException("Location " + certificateLocation.getLocation().getName() + " does not support key management");
         }
 
+        Certificate certificateInScope = certificateService.getCertificateEntity(certificateUuid);
+        if(certificateInScope.getRaProfile() == null) {
+            logger.debug("Certificate {} is not associated with any RA Profile. Cannot renew the certificate", certificateInScope.getCommonName());
+            throw new LocationException("Certificate is not associated with any RA Profile. Cannot renew the certificate in the location");
+        }
+
         // remove the current certificate from location
         removeCertificateFromLocation(certificateLocation.getLocation().getUuid(), certificateLocation.getCertificate().getUuid());
 


### PR DESCRIPTION
When the renew action for the certificate in the location is triggered and if the Certificate does not have the RA Profile, the code currently fails with null pointer exception.

This fix adds additional check if the certificate does not have the RA Profile then the renewal will fail with the custom message