### PR TITLE
Update renewal and issue certificate to location logic

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/LocationManagementControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/LocationManagementControllerImpl.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.api.web;
 
 import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.LocationException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.interfaces.core.web.LocationManagementController;
@@ -107,7 +108,7 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    public LocationDto issueCertificate(String entityUuid, String locationUuid, IssueToLocationRequestDto request) throws NotFoundException, LocationException {
+    public LocationDto issueCertificate(String entityUuid, String locationUuid, IssueToLocationRequestDto request) throws ConnectorException, LocationException {
         return locationService.issueCertificateToLocation(
                 SecuredParentUUID.fromString(entityUuid),
                 SecuredUUID.fromString(locationUuid),
@@ -122,7 +123,7 @@ public class LocationManagementControllerImpl implements LocationManagementContr
     }
 
     @Override
-    public LocationDto renewCertificateInLocation(String entityUuid, String locationUuid, String certificateUuid) throws NotFoundException, LocationException {
+    public LocationDto renewCertificateInLocation(String entityUuid, String locationUuid, String certificateUuid) throws ConnectorException, LocationException {
         return locationService.renewCertificateInLocation(
                 SecuredParentUUID.fromString(entityUuid),
                 SecuredUUID.fromString(locationUuid),

--- a/src/main/java/com/czertainly/core/service/LocationService.java
+++ b/src/main/java/com/czertainly/core/service/LocationService.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.service;
 
 import com.czertainly.api.exception.AlreadyExistException;
+import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.LocationException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
@@ -149,7 +150,7 @@ public interface LocationService {
      * @throws NotFoundException when the Location with the given UUID is not found.
      * @throws LocationException when the Certificate failed to be issued to the Location.
      */
-    LocationDto issueCertificateToLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, String raProfileUuid, IssueToLocationRequestDto issueToLocationRequestDto) throws NotFoundException, LocationException;
+    LocationDto issueCertificateToLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, String raProfileUuid, IssueToLocationRequestDto issueToLocationRequestDto) throws NotFoundException, LocationException, ConnectorException;
 
     /**
      * Synchronize and update content for the given Location.
@@ -172,6 +173,6 @@ public interface LocationService {
      * @throws NotFoundException when the Location or Certificate with the given UUID is not found.
      * @throws LocationException when the Certificate failed to be renewed in the Location.
      */
-    LocationDto renewCertificateInLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, SecuredUUID certificateUuid) throws NotFoundException, LocationException;
+    LocationDto renewCertificateInLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, SecuredUUID certificateUuid) throws NotFoundException, LocationException, ConnectorException;
 
 }


### PR DESCRIPTION
This PR contains the following changes:

1. Check and remove the cache data from the location if the certificate is failed to issue
2. Update the logics of the renew to include other needed new parameters
3. Add prechecks for the ra profile, authority and connector