### PR TITLE
Remove old certificate reference after renewal in location

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/LocationManagementControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/LocationManagementControllerImpl.java
@@ -127,7 +127,7 @@ public class LocationManagementControllerImpl implements LocationManagementContr
         return locationService.renewCertificateInLocation(
                 SecuredParentUUID.fromString(entityUuid),
                 SecuredUUID.fromString(locationUuid),
-                SecuredUUID.fromString(certificateUuid));
+                certificateUuid);
     }
 
 }

--- a/src/main/java/com/czertainly/core/service/LocationService.java
+++ b/src/main/java/com/czertainly/core/service/LocationService.java
@@ -173,6 +173,6 @@ public interface LocationService {
      * @throws NotFoundException when the Location or Certificate with the given UUID is not found.
      * @throws LocationException when the Certificate failed to be renewed in the Location.
      */
-    LocationDto renewCertificateInLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, SecuredUUID certificateUuid) throws NotFoundException, LocationException, ConnectorException;
+    LocationDto renewCertificateInLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, String certificateUuid) throws NotFoundException, LocationException, ConnectorException;
 
 }


### PR DESCRIPTION
When the certificate is renewed in the location, remove the old reference. If the reference is not removed then old data along with the new data is sent in the API response