### PR TITLE
Mask secrets in credential attributes responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.czertainly</groupId>
     <artifactId>core</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
     <name>CZERTAINLY-Core</name>
 
     <properties>

--- a/src/main/java/com/czertainly/core/api/web/RAProfileManagementControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/RAProfileManagementControllerImpl.java
@@ -113,8 +113,8 @@ public class RAProfileManagementControllerImpl implements RAProfileManagementCon
     }
 
     @Override
-    public void deactivateAcmeForRaProfile(String authorityUuid, String uuid) throws NotFoundException {
-        raProfileService.deactivateAcmeForRaProfile(SecuredParentUUID.fromString(authorityUuid), SecuredUUID.fromString(uuid));
+    public void deactivateAcmeForRaProfile(String authorityUuid, String raProfileUuid) throws NotFoundException {
+        raProfileService.deactivateAcmeForRaProfile(SecuredParentUUID.fromString(authorityUuid), SecuredUUID.fromString(raProfileUuid));
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/dao/entity/DiscoveryHistory.java
+++ b/src/main/java/com/czertainly/core/dao/entity/DiscoveryHistory.java
@@ -5,6 +5,7 @@ import com.czertainly.api.model.core.discovery.DiscoveryStatus;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.DtoMapper;
 import com.czertainly.core.util.MetaDefinitions;
+import com.czertainly.core.util.SecretMaskingUtil;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -199,7 +200,7 @@ public class DiscoveryHistory extends UniquelyIdentifiedAndAudited implements Se
         dto.setStatus(status);
         dto.setCertificate(certificate.stream().map(DiscoveryCertificate::mapToDto).collect(Collectors.toList()));
         dto.setConnectorUuid(connectorUuid.toString());
-        dto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(AttributeDefinitionUtils.deserialize(attributes)));
+        dto.setAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(AttributeDefinitionUtils.deserialize(attributes))));
         dto.setKind(kind);
         dto.setMessage(message);
         dto.setConnectorName(connectorName);

--- a/src/main/java/com/czertainly/core/dao/entity/Location.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Location.java
@@ -7,6 +7,7 @@ import com.czertainly.api.model.core.location.LocationDto;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.DtoMapper;
 import com.czertainly.core.util.MetaDefinitions;
+import com.czertainly.core.util.SecretMaskingUtil;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -179,8 +180,8 @@ public class Location extends UniquelyIdentifiedAndAudited implements Serializab
             cilDto.setSerialNumber(certificateLocation.getCertificate().getSerialNumber());
             cilDto.setCertificateUuid(certificateLocation.getCertificate().getUuid().toString());
             cilDto.setWithKey(certificateLocation.isWithKey());
-            cilDto.setPushAttributes(AttributeDefinitionUtils.getClientAttributes(certificateLocation.getPushAttributes()));
-            cilDto.setCsrAttributes(AttributeDefinitionUtils.getClientAttributes(certificateLocation.getCsrAttributes()));
+            cilDto.setPushAttributes(AttributeDefinitionUtils.getClientAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(certificateLocation.getPushAttributes()))));
+            cilDto.setCsrAttributes(AttributeDefinitionUtils.getClientAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(certificateLocation.getCsrAttributes()))));
 
             cilDtoList.add(cilDto);
         }

--- a/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -11,13 +11,18 @@ import com.czertainly.api.model.client.authority.AuthorityInstanceUpdateRequestD
 import com.czertainly.api.model.common.BulkActionMessageDto;
 import com.czertainly.api.model.common.NameAndIdDto;
 import com.czertainly.api.model.common.attribute.AttributeDefinition;
+import com.czertainly.api.model.common.attribute.AttributeType;
 import com.czertainly.api.model.common.attribute.RequestAttributeDto;
+import com.czertainly.api.model.common.attribute.ResponseAttributeDto;
+import com.czertainly.api.model.common.attribute.content.BaseAttributeContent;
+import com.czertainly.api.model.common.attribute.content.JsonAttributeContent;
 import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceDto;
 import com.czertainly.api.model.connector.authority.AuthorityProviderInstanceRequestDto;
 import com.czertainly.api.model.core.audit.ObjectType;
 import com.czertainly.api.model.core.audit.OperationType;
 import com.czertainly.api.model.core.authority.AuthorityInstanceDto;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
+import com.czertainly.api.model.core.credential.CredentialDto;
 import com.czertainly.core.aop.AuditLogged;
 import com.czertainly.core.dao.entity.AuthorityInstanceReference;
 import com.czertainly.core.dao.entity.Connector;
@@ -34,6 +39,8 @@ import com.czertainly.core.service.ConnectorService;
 import com.czertainly.core.service.CredentialService;
 import com.czertainly.core.service.RaProfileService;
 import com.czertainly.core.util.AttributeDefinitionUtils;
+import com.czertainly.core.util.SecretMaskingUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +48,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -93,7 +101,7 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
         AuthorityProviderInstanceDto authorityProviderInstanceDto = authorityInstanceApiClient.getAuthorityInstance(authorityInstanceReference.getConnector().mapToDto(),
                 authorityInstanceReference.getAuthorityInstanceUuid());
 
-        authorityInstanceDto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(authorityProviderInstanceDto.getAttributes()));
+        authorityInstanceDto.setAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(authorityProviderInstanceDto.getAttributes())));
         authorityInstanceDto.setName(authorityProviderInstanceDto.getName());
         authorityInstanceDto.setConnectorName(authorityInstanceReference.getConnector().getName());
         authorityInstanceDto.setConnectorUuid(authorityInstanceReference.getConnector().getUuid().toString());

--- a/src/main/java/com/czertainly/core/service/impl/EntityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/EntityInstanceServiceImpl.java
@@ -24,6 +24,7 @@ import com.czertainly.core.service.ConnectorService;
 import com.czertainly.core.service.CredentialService;
 import com.czertainly.core.service.EntityInstanceService;
 import com.czertainly.core.util.AttributeDefinitionUtils;
+import com.czertainly.core.util.SecretMaskingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,7 +90,7 @@ public class EntityInstanceServiceImpl implements EntityInstanceService {
                 entityInstanceReference.getEntityInstanceUuid());
 
         EntityInstanceDto entityInstanceDto = new EntityInstanceDto();
-        entityInstanceDto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(entityProviderInstanceDto.getAttributes()));
+        entityInstanceDto.setAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(entityProviderInstanceDto.getAttributes())));
         entityInstanceDto.setName(entityProviderInstanceDto.getName());
         entityInstanceDto.setUuid(entityInstanceReference.getUuid().toString());
         entityInstanceDto.setConnectorUuid(entityInstanceReference.getConnector().getUuid().toString());

--- a/src/main/java/com/czertainly/core/util/SecretMaskingUtil.java
+++ b/src/main/java/com/czertainly/core/util/SecretMaskingUtil.java
@@ -18,7 +18,9 @@ public class SecretMaskingUtil {
     public static List<ResponseAttributeDto> maskSecret(List<ResponseAttributeDto> responseAttributeDtos) {
         List<ResponseAttributeDto> responses = new ArrayList<>();
         for (ResponseAttributeDto responseAttributeDto : responseAttributeDtos) {
-            if (TO_BE_MASKED.contains(responseAttributeDto.getType())) {
+            if (responseAttributeDto.getType() == null) {
+                //Do nothing
+            } else if (TO_BE_MASKED.contains(responseAttributeDto.getType())) {
                 responseAttributeDto.setContent(new BaseAttributeContent<String>(null));
             } else if (responseAttributeDto.getType().equals(AttributeType.CREDENTIAL)) {
                 ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/src/main/java/com/czertainly/core/util/SecretMaskingUtil.java
+++ b/src/main/java/com/czertainly/core/util/SecretMaskingUtil.java
@@ -1,0 +1,43 @@
+package com.czertainly.core.util;
+
+import com.czertainly.api.model.common.attribute.AttributeType;
+import com.czertainly.api.model.common.attribute.ResponseAttributeDto;
+import com.czertainly.api.model.common.attribute.content.BaseAttributeContent;
+import com.czertainly.api.model.common.attribute.content.JsonAttributeContent;
+import com.czertainly.api.model.core.credential.CredentialDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+public class SecretMaskingUtil {
+
+    private static final List<AttributeType> TO_BE_MASKED = List.of(AttributeType.SECRET);
+
+    public static List<ResponseAttributeDto> maskSecret(List<ResponseAttributeDto> responseAttributeDtos) {
+        List<ResponseAttributeDto> responses = new ArrayList<>();
+        for (ResponseAttributeDto responseAttributeDto : responseAttributeDtos) {
+            if (TO_BE_MASKED.contains(responseAttributeDto.getType())) {
+                responseAttributeDto.setContent(new BaseAttributeContent<String>(null));
+            } else if (responseAttributeDto.getType().equals(AttributeType.CREDENTIAL)) {
+                ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+                CredentialDto credentialDto = OBJECT_MAPPER.convertValue(((LinkedHashMap) responseAttributeDto.getContent()).get("data"), CredentialDto.class);
+                List<ResponseAttributeDto> credentialAttrs = new ArrayList<>();
+                if (credentialDto.getAttributes() == null) {
+                    responseAttributeDto.setContent(null);
+                } else {
+                    for (ResponseAttributeDto credentialAttributeDto : credentialDto.getAttributes()) {
+                        if (TO_BE_MASKED.contains(credentialAttributeDto.getType())) {
+                            credentialAttributeDto.setContent(new BaseAttributeContent<String>(null));
+                        }
+                        credentialAttrs.add(credentialAttributeDto);
+                    }
+                    responseAttributeDto.setContent(new JsonAttributeContent(credentialDto.getName(), credentialDto));
+                }
+            }
+            responses.add(responseAttributeDto);
+        }
+        return responseAttributeDtos;
+    }
+}


### PR DESCRIPTION
When the objects like Authority instances and discoveries are retrieved, mask the secret in the credential dto before sending it as response

closes #202 