### PR TITLE
Fix CertificateInLocationDto attribute properties type

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Location.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Location.java
@@ -168,8 +168,8 @@ public class Location extends UniquelyIdentifiedAndAudited implements Serializab
             cilDto.setSerialNumber(certificateLocation.getCertificate().getSerialNumber());
             cilDto.setCertificateUuid(certificateLocation.getCertificate().getUuid().toString());
             cilDto.setWithKey(certificateLocation.isWithKey());
-            cilDto.setPushAttributes(AttributeDefinitionUtils.getClientAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(certificateLocation.getPushAttributes()))));
-            cilDto.setCsrAttributes(AttributeDefinitionUtils.getClientAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(certificateLocation.getCsrAttributes()))));
+            cilDto.setPushAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(certificateLocation.getPushAttributes())));
+            cilDto.setCsrAttributes(SecretMaskingUtil.maskSecret(AttributeDefinitionUtils.getResponseAttributes(certificateLocation.getCsrAttributes())));
 
             cilDtoList.add(cilDto);
         }


### PR DESCRIPTION
- use ResponseAttributeDto  instead of RequestAttributeDto when setting push and CSR attributes of CertificateInLocationDto

[Related PR](https://github.com/3KeyCompany/CZERTAINLY-Interfaces/pull/118)