### PR TITLE
Check for duplicates with same attributes before creating location

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Location.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Location.java
@@ -91,6 +91,10 @@ public class Location extends UniquelyIdentifiedAndAudited implements Serializab
         return AttributeDefinitionUtils.deserializeRequestAttributes(this.attributes);
     }
 
+    public List<DataAttribute> getAttributes() {
+        return AttributeDefinitionUtils.deserialize(this.attributes, DataAttribute.class);
+    }
+
     public void setAttributes(List<DataAttribute> attributes) {
         this.attributes = AttributeDefinitionUtils.serialize(attributes);
     }

--- a/src/main/java/com/czertainly/core/dao/repository/LocationRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/LocationRepository.java
@@ -1,5 +1,6 @@
 package com.czertainly.core.dao.repository;
 
+import com.czertainly.core.dao.entity.EntityInstanceReference;
 import com.czertainly.core.dao.entity.Location;
 import org.springframework.stereotype.Repository;
 
@@ -14,7 +15,7 @@ public interface LocationRepository extends SecurityFilterRepository<Location, L
 
     Optional<Location> findByName(String name);
 
-    List<Location> findByEnabled(Boolean isEnabled);
+    List<Location> findByEntityInstanceReference(EntityInstanceReference entityInstanceReference);
 
     Optional<Location> findByUuidAndEnabledIsTrue(UUID uuid);
 

--- a/src/test/java/com/czertainly/core/service/LocationServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/LocationServiceTest.java
@@ -4,6 +4,7 @@ import com.czertainly.api.exception.AlreadyExistException;
 import com.czertainly.api.exception.LocationException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.attribute.RequestAttributeDto;
 import com.czertainly.api.model.client.location.AddLocationRequestDto;
 import com.czertainly.api.model.client.location.EditLocationRequestDto;
 import com.czertainly.api.model.client.location.IssueToLocationRequestDto;
@@ -11,6 +12,7 @@ import com.czertainly.api.model.client.location.PushToLocationRequestDto;
 import com.czertainly.api.model.common.attribute.v2.AttributeType;
 import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContent;
 import com.czertainly.api.model.common.attribute.v2.properties.DataAttributeProperties;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.location.LocationDto;
@@ -248,7 +250,10 @@ public class LocationServiceTest extends BaseSpringBootTest {
 
         AddLocationRequestDto request = new AddLocationRequestDto();
         request.setName("testLocation2");
-        request.setAttributes(List.of());
+        RequestAttributeDto requestAttributeDto = new RequestAttributeDto();
+        requestAttributeDto.setName("sample");
+        requestAttributeDto.setContent(List.of(new StringAttributeContent("test")));
+        request.setAttributes(List.of(requestAttributeDto));
 
         LocationDto dto = locationService.addLocation(SecuredParentUUID.fromUUID(entityInstanceReference.getUuid()),request);
         Assertions.assertNotNull(dto);


### PR DESCRIPTION
This PR Contains changes to the following:

Updates to the logic to create a location. When a location is being created, the new logic checks for the type of content and validates if any location with the same attributes already exists in the database and throws an error.

closes #204 