### PR TITLE
Split DiscoveryHistoryDto from DiscoveryHistoryDetailDto

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/DiscoveryControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/DiscoveryControllerImpl.java
@@ -5,8 +5,9 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.interfaces.core.web.DiscoveryController;
 import com.czertainly.api.model.client.discovery.DiscoveryDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDto;
 import com.czertainly.api.model.common.UuidDto;
-import com.czertainly.api.model.core.discovery.DiscoveryHistoryDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDetailDto;
 import com.czertainly.core.dao.entity.DiscoveryHistory;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
@@ -33,7 +34,7 @@ public class DiscoveryControllerImpl implements DiscoveryController {
 	}
 
 	@Override
-	public DiscoveryHistoryDto getDiscovery(@PathVariable String uuid) throws NotFoundException {
+	public DiscoveryHistoryDetailDto getDiscovery(@PathVariable String uuid) throws NotFoundException {
 		return discoveryService.getDiscovery(SecuredUUID.fromString(uuid));
 	}
 

--- a/src/main/java/com/czertainly/core/dao/entity/DiscoveryHistory.java
+++ b/src/main/java/com/czertainly/core/dao/entity/DiscoveryHistory.java
@@ -1,7 +1,8 @@
 package com.czertainly.core.dao.entity;
 
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDto;
 import com.czertainly.api.model.common.attribute.v2.DataAttribute;
-import com.czertainly.api.model.core.discovery.DiscoveryHistoryDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDetailDto;
 import com.czertainly.api.model.core.discovery.DiscoveryStatus;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.DtoMapper;
@@ -25,7 +26,7 @@ import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "discovery_history")
-public class DiscoveryHistory extends UniquelyIdentifiedAndAudited implements Serializable, DtoMapper<DiscoveryHistoryDto> {
+public class DiscoveryHistory extends UniquelyIdentifiedAndAudited implements Serializable, DtoMapper<DiscoveryHistoryDetailDto> {
 
     /**
      *
@@ -178,8 +179,8 @@ public class DiscoveryHistory extends UniquelyIdentifiedAndAudited implements Se
     }
 
     @Override
-    public DiscoveryHistoryDto mapToDto() {
-        DiscoveryHistoryDto dto = new DiscoveryHistoryDto();
+    public DiscoveryHistoryDetailDto mapToDto() {
+        DiscoveryHistoryDetailDto dto = new DiscoveryHistoryDetailDto();
         dto.setUuid(uuid.toString());
         dto.setName(name);
         dto.setEndTime(endTime);
@@ -192,6 +193,20 @@ public class DiscoveryHistory extends UniquelyIdentifiedAndAudited implements Se
         dto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(a));
         dto.setKind(kind);
         dto.setMessage(message);
+        dto.setConnectorName(connectorName);
+        return dto;
+    }
+
+    public DiscoveryHistoryDto mapToListDto() {
+        DiscoveryHistoryDto dto = new DiscoveryHistoryDto();
+        dto.setUuid(uuid.toString());
+        dto.setName(name);
+        dto.setEndTime(endTime);
+        dto.setStartTime(startTime);
+        dto.setTotalCertificatesDiscovered(totalCertificatesDiscovered);
+        dto.setStatus(status);
+        dto.setConnectorUuid(connectorUuid.toString());
+        dto.setKind(kind);
         dto.setConnectorName(connectorName);
         return dto;
     }

--- a/src/main/java/com/czertainly/core/service/DiscoveryService.java
+++ b/src/main/java/com/czertainly/core/service/DiscoveryService.java
@@ -4,7 +4,8 @@ import com.czertainly.api.exception.AlreadyExistException;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.model.client.discovery.DiscoveryDto;
-import com.czertainly.api.model.core.discovery.DiscoveryHistoryDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDetailDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDto;
 import com.czertainly.core.dao.entity.DiscoveryHistory;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
@@ -14,7 +15,7 @@ import java.util.List;
 public interface DiscoveryService {
 
     List<DiscoveryHistoryDto> listDiscoveries(SecurityFilter filter);
-    DiscoveryHistoryDto getDiscovery(SecuredUUID uuid) throws NotFoundException;
+    DiscoveryHistoryDetailDto getDiscovery(SecuredUUID uuid) throws NotFoundException;
     DiscoveryHistory createDiscoveryModal(DiscoveryDto request) throws AlreadyExistException, ConnectorException;
 
     void createDiscovery(DiscoveryDto request, DiscoveryHistory modal) throws AlreadyExistException, NotFoundException, ConnectorException;

--- a/src/test/java/com/czertainly/core/service/DiscoveryServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/DiscoveryServiceTest.java
@@ -5,9 +5,10 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.client.discovery.DiscoveryDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDto;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
-import com.czertainly.api.model.core.discovery.DiscoveryHistoryDto;
+import com.czertainly.api.model.client.discovery.DiscoveryHistoryDetailDto;
 import com.czertainly.core.dao.entity.Connector;
 import com.czertainly.core.dao.entity.Connector2FunctionGroup;
 import com.czertainly.core.dao.entity.DiscoveryHistory;
@@ -102,7 +103,7 @@ public class DiscoveryServiceTest extends BaseSpringBootTest {
 
     @Test
     public void testGetDiscovery() throws NotFoundException {
-        DiscoveryHistoryDto dto = discoveryService.getDiscovery(discovery.getSecuredUuid());
+        DiscoveryHistoryDetailDto dto = discoveryService.getDiscovery(discovery.getSecuredUuid());
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(discovery.getUuid().toString(), dto.getUuid());
         Assertions.assertEquals(discovery.getConnectorUuid().toString(), dto.getConnectorUuid());


### PR DESCRIPTION
This Pull contains the changes for the following:

1. Split the DTOs for the discovery
2. Core updates based on the connector

links 3KeyCompany/CZERTAINLY-Interfaces#127