### PR TITLE
Fix Certificate Pagination details in the certificate list response

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -771,6 +771,8 @@ public class CertificateServiceImpl implements CertificateService {
                     .collect(Collectors.toList()
                     )
             );
+            certificateResponseDto.setItemsPerPage(request.getItemsPerPage());
+            certificateResponseDto.setPageNumber(request.getPageNumber());
         } else {
             DynamicSearchInternalResponse dynamicSearchInternalResponse = searchService.dynamicSearchQueryExecutor(request, "Certificate", getSearchableFieldInformation(), searchService.createCriteriaBuilderString(filter, true));
             certificateResponseDto.setItemsPerPage(request.getItemsPerPage());

--- a/src/main/java/com/czertainly/core/service/impl/SearchServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/SearchServiceImpl.java
@@ -150,7 +150,7 @@ public class SearchServiceImpl implements SearchService {
             dynamicSearchInternalResponse.setResult(new ArrayList<>());
             entityManager.close();
         } else {
-            Query countQuery = entityManager.createQuery(sqlQuery.replace("select c from", "select COUNT(c) from").replace(" GROUP BY c.id ORDER BY c.id DESC", ""));
+            Query countQuery = entityManager.createQuery(sqlQuery.replace("select c from", "select COUNT(c) from").split(" GROUP BY ")[0]);
             Long totalItems = (Long) countQuery.getSingleResult();
             dynamicSearchInternalResponse.setTotalPages((int) Math.ceil((double) totalItems / searchRequestDto.getItemsPerPage()));
             dynamicSearchInternalResponse.setTotalItems(totalItems);


### PR DESCRIPTION
When the list of certificates is requested, the list API does not contain the correct information.

This PR contains the the changes for the following:

1. Certificate List API without filter - Add Items per page and current page number
2. Certificate List API with filter - Fix number of items per page

closes #212