### PR TITLE
Update credential Attribute content to new class

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Credential.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Credential.java
@@ -2,6 +2,8 @@ package com.czertainly.core.dao.entity;
 
 import com.czertainly.api.model.common.NameAndUuidDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
+import com.czertainly.api.model.common.attribute.v2.DataAttribute;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.DtoMapper;
@@ -40,7 +42,7 @@ public class Credential extends UniquelyIdentifiedAndAudited implements Serializ
     @Column(name = "connector_uuid")
     private UUID connectorUuid;
 
-    @Column(name="connector_name")
+    @Column(name = "connector_name")
     private String connectorName;
 
     public String getName() {
@@ -83,9 +85,13 @@ public class Credential extends UniquelyIdentifiedAndAudited implements Serializ
         this.connectorUuid = connectorUuid;
     }
 
-    public String getConnectorName() { return connectorName; }
+    public String getConnectorName() {
+        return connectorName;
+    }
 
-    public void setConnectorName(String connectorName) { this.connectorName = connectorName; }
+    public void setConnectorName(String connectorName) {
+        this.connectorName = connectorName;
+    }
 
     public CredentialDto mapToDtoSimple() {
         CredentialDto dto = new CredentialDto();
@@ -94,7 +100,7 @@ public class Credential extends UniquelyIdentifiedAndAudited implements Serializ
         dto.setKind(this.kind);
         dto.setEnabled(this.enabled);
         dto.setConnectorName(this.connectorName);
-        if(this.connectorUuid != null) {
+        if (this.connectorUuid != null) {
             dto.setConnectorUuid(this.connectorUuid.toString());
         }
 
@@ -110,10 +116,19 @@ public class Credential extends UniquelyIdentifiedAndAudited implements Serializ
         dto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(AttributeDefinitionUtils.deserialize(this.attributes, BaseAttribute.class)));
         dto.setEnabled(this.enabled);
         dto.setConnectorName(this.connectorName);
-        if(this.connectorUuid != null) {
+        if (this.connectorUuid != null) {
             dto.setConnectorUuid(this.connectorUuid.toString());
         }
 
+        return dto;
+    }
+
+    public CredentialAttributeContentData mapToCredentialContent() {
+        CredentialAttributeContentData dto = new CredentialAttributeContentData();
+        dto.setUuid(this.uuid.toString());
+        dto.setName(this.name);
+        dto.setKind(this.kind);
+        dto.setAttributes(AttributeDefinitionUtils.deserialize(this.attributes, DataAttribute.class));
         return dto;
     }
 

--- a/src/main/java/com/czertainly/core/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CredentialServiceImpl.java
@@ -5,7 +5,6 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationError;
 import com.czertainly.api.exception.ValidationException;
-import com.czertainly.api.model.client.attribute.ResponseAttributeDto;
 import com.czertainly.api.model.client.credential.CredentialRequestDto;
 import com.czertainly.api.model.client.credential.CredentialUpdateRequestDto;
 import com.czertainly.api.model.common.NameAndUuidDto;
@@ -17,7 +16,7 @@ import com.czertainly.api.model.common.attribute.v2.callback.RequestAttributeCal
 import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
 import com.czertainly.api.model.common.attribute.v2.content.CredentialAttributeContent;
 import com.czertainly.api.model.common.attribute.v2.content.ObjectAttributeContent;
-import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.audit.ObjectType;
 import com.czertainly.api.model.core.audit.OperationType;
 import com.czertainly.api.model.core.auth.Resource;
@@ -26,7 +25,6 @@ import com.czertainly.api.model.core.connector.FunctionGroupCode;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.czertainly.core.aop.AuditLogged;
 import com.czertainly.core.dao.entity.Credential;
-import com.czertainly.core.dao.entity.acme.AcmeProfile;
 import com.czertainly.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.czertainly.core.dao.repository.CredentialRepository;
 import com.czertainly.core.model.auth.ResourceAction;
@@ -223,7 +221,7 @@ public class CredentialServiceImpl implements CredentialService {
 
             NameAndUuidDto credentialId = AttributeDefinitionUtils.getNameAndUuidData(attribute.getName(), AttributeDefinitionUtils.getClientAttributes(attributes));
             Credential credential = getCredentialEntity(SecuredUUID.fromString(credentialId.getUuid()));
-            attribute.setContent(List.of(new CredentialAttributeContent(credentialId.getName(), credential.mapToDto())));
+            attribute.setContent(List.of(new CredentialAttributeContent(credentialId.getName(), credential.mapToCredentialContent())));
             logger.debug("Value of Credential Attribute {} updated.", attribute.getName());
         }
     }
@@ -280,7 +278,7 @@ public class CredentialServiceImpl implements CredentialService {
                                             "Invalid value {}. Instance of {} is expected.", bodyKeyValue, NameAndUuidDto.class));
                                 }
 
-                                CredentialDto credential = getCredentialEntity(SecuredUUID.fromString(credentialUuid)).mapToDto();
+                                CredentialAttributeContentData credential = getCredentialEntity(SecuredUUID.fromString(credentialUuid)).mapToCredentialContent();
                                 ArrayList<CredentialAttributeContent> credAttributes = new ArrayList<>();
                                 credAttributes.add(new CredentialAttributeContent(referenceName, credential));
                                 requestAttributeCallback.getBody().put(mapping.getTo(), credAttributes);

--- a/src/test/java/com/czertainly/core/service/CredentialServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CredentialServiceTest.java
@@ -15,6 +15,7 @@ import com.czertainly.api.model.common.attribute.v2.callback.AttributeValueTarge
 import com.czertainly.api.model.common.attribute.v2.callback.RequestAttributeCallback;
 import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
 import com.czertainly.api.model.common.attribute.v2.content.CredentialAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
 import com.czertainly.api.model.core.credential.CredentialDto;
@@ -229,7 +230,7 @@ public class CredentialServiceTest extends BaseSpringBootTest {
 
     @Test
     public void testLoadFullData_attributes() throws NotFoundException {
-        CredentialDto dto = new CredentialDto();
+        CredentialAttributeContentData dto = new CredentialAttributeContentData();
         CredentialAttributeContent nameAndUuidMap = new CredentialAttributeContent();
         dto.setUuid(credential.getUuid().toString());
         dto.setName(credential.getName());
@@ -244,16 +245,16 @@ public class CredentialServiceTest extends BaseSpringBootTest {
 
         credentialService.loadFullCredentialData(attrs);
 
-        Assertions.assertTrue(attrs.get(0).getContent().get(0).getData() instanceof CredentialDto);
+        Assertions.assertTrue(attrs.get(0).getContent().get(0).getData() instanceof CredentialAttributeContentData);
 
-        CredentialDto credentialDto = ((CredentialAttributeContent) attrs.get(0).getContent().get(0)).getData();
+        CredentialAttributeContentData credentialDto = ((CredentialAttributeContent) attrs.get(0).getContent().get(0)).getData();
         Assertions.assertEquals(credential.getUuid().toString(), credentialDto.getUuid());
         Assertions.assertEquals(credential.getName(), credentialDto.getName());
     }
 
     @Test
     public void testLoadFullData_attributesNotFound() throws NotFoundException {
-        CredentialDto dto = new CredentialDto();
+        CredentialAttributeContentData dto = new CredentialAttributeContentData();
         CredentialAttributeContent nameAndUuidMap = new CredentialAttributeContent();
         dto.setUuid("abfbc322-29e1-11ed-a261-0242ac120002");
         dto.setName("wrong-name");
@@ -278,7 +279,7 @@ public class CredentialServiceTest extends BaseSpringBootTest {
     public void testLoadFullData_callback() throws NotFoundException {
         String credentialBodyKey = "testCredential";
 
-        CredentialDto dto = new CredentialDto();
+        CredentialAttributeContentData dto = new CredentialAttributeContentData();
         CredentialAttributeContent nameAndUuidMap = new CredentialAttributeContent();
         dto.setUuid(credential.getUuid().toString());
         dto.setName(credential.getName());
@@ -304,9 +305,9 @@ public class CredentialServiceTest extends BaseSpringBootTest {
 
         credentialService.loadFullCredentialData(callback, requestAttributeCallback);
 
-        Assertions.assertTrue(((List<CredentialAttributeContent>)requestAttributeCallback.getBody().get(credentialBodyKey)).get(0).getData() instanceof CredentialDto);
+        Assertions.assertTrue(((List<CredentialAttributeContent>)requestAttributeCallback.getBody().get(credentialBodyKey)).get(0).getData() instanceof CredentialAttributeContentData);
 
-        CredentialDto credentialDto = ((List<CredentialAttributeContent>) requestAttributeCallback.getBody().get(credentialBodyKey)).get(0).getData();
+        CredentialAttributeContentData credentialDto = ((List<CredentialAttributeContent>) requestAttributeCallback.getBody().get(credentialBodyKey)).get(0).getData();
         Assertions.assertEquals(credential.getUuid().toString(), credentialDto.getUuid());
         Assertions.assertEquals(credential.getName(), credentialDto.getName());
     }
@@ -315,7 +316,7 @@ public class CredentialServiceTest extends BaseSpringBootTest {
     public void testLoadFullData_callbackValidation() {
         String credentialBodyKey = "testCredential";
 
-        CredentialDto dto = new CredentialDto();
+        CredentialAttributeContentData dto = new CredentialAttributeContentData();
         CredentialAttributeContent nameAndUuidMap = new CredentialAttributeContent();
         dto.setUuid("abfbc322-29e1-11ed-a261-0242ac120002");
         dto.setName("wrong-name");

--- a/src/test/java/com/czertainly/core/util/JsonSerializationTest.java
+++ b/src/test/java/com/czertainly/core/util/JsonSerializationTest.java
@@ -4,6 +4,7 @@ import com.czertainly.api.model.common.NameAndIdDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
 import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.CredentialAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.audit.AuditLogFilter;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -82,7 +83,7 @@ public class JsonSerializationTest {
 
     @Test
     public void testSerializeCredential() {
-        CredentialDto credential = new CredentialDto();
+        CredentialAttributeContentData credential = new CredentialAttributeContentData();
         credential.setName("test");
 
         List<DataAttribute> attrs = AttributeDefinitionUtils.clientAttributeConverter(AttributeDefinitionUtils.createAttributes("credential", List.of(new CredentialAttributeContent("test", credential))));
@@ -91,12 +92,8 @@ public class JsonSerializationTest {
 
         List<DataAttribute> deserialized = AttributeDefinitionUtils.deserialize(serialized, DataAttribute.class);
 
-        CredentialDto value = AttributeDefinitionUtils.getCredentialContent("credential", AttributeDefinitionUtils.getClientAttributes(deserialized));
+        CredentialAttributeContentData value = AttributeDefinitionUtils.getCredentialContent("credential", AttributeDefinitionUtils.getClientAttributes(deserialized));
         Assertions.assertNotNull(value);
-
-        CredentialDto converted = MAPPER.convertValue(value, CredentialDto.class);
-
-        Assertions.assertEquals(CredentialDto.class, converted.getClass());
     }
 
 }


### PR DESCRIPTION
For the credential Attribute type, create a new data type for the content as the credential to contains ResponseAttributeDto and will not propagate the secrets to the connector

links 3KeyCompany/CZERTAINLY-Interfaces#133