### PR TITLE
Remove Lazy Loading of Attributes in Connector

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Connector.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Connector.java
@@ -36,8 +36,7 @@ public class Connector extends UniquelyIdentifiedAndAudited implements Serializa
     @Column(name = "auth_type")
     @Enumerated(EnumType.STRING)
     private AuthType authType;
-
-    @Basic(fetch = FetchType.LAZY)
+    
     @Column(name = "auth_attributes")
     private String authAttributes;
 


### PR DESCRIPTION
When the connector entity is loaded, remove the lazy loading of the Auth Attributes