### PR TITLE
Set the certificate data as empty list

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Location.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Location.java
@@ -201,7 +201,9 @@ public class Location extends UniquelyIdentifiedAndAudited implements Serializab
         dto.setEnabled(enabled);
         dto.setSupportMultipleEntries(supportMultipleEntries);
         dto.setSupportKeyManagement(supportKeyManagement);
-
+        //TODO - Create a new DTO for the list location operation. Has to be done when creating the objects for other
+        // similar operation
+        dto.setCertificates(List.of());
         return dto;
     }
 


### PR DESCRIPTION
When the list of locations for the certificate is requested, currently the response is not set. This causes the UI to fail load. So setting the certificate column an empty list, will make the UI load correctly