### PR TITLE
Add Certificate UUID to the Discovery UUID

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/CertificateContent.java
+++ b/src/main/java/com/czertainly/core/dao/entity/CertificateContent.java
@@ -1,49 +1,76 @@
 package com.czertainly.core.dao.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "certificate_content")
 public class CertificateContent {
-	@Id
-	@Column(name = "id")
-	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "certificate_content_seq")
-	@SequenceGenerator(name = "certificate_content_seq", sequenceName = "certificate_content_id_seq", allocationSize = 1)
-	private Long id;
-	
-	@Column(name = "fingerprint")
-	private String fingerprint;
-	
-	@Column(name = "content", length = 8192)
-	private String content;
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "certificate_content_seq")
+    @SequenceGenerator(name = "certificate_content_seq", sequenceName = "certificate_content_id_seq", allocationSize = 1)
+    private Long id;
 
-	public Long getId() {
-		return id;
+    @Column(name = "fingerprint")
+    private String fingerprint;
+
+    @Column(name = "content", length = 8192)
+    private String content;
+
+    @OneToMany(mappedBy = "certificateContent")
+    @JsonIgnore
+    private Set<DiscoveryCertificate> discoveryCertificates = new HashSet<>();
+
+    @OneToOne(mappedBy = "certificateContent")
+    @JsonIgnore
+    private Certificate certificate;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFingerprint() {
+        return fingerprint;
+    }
+
+    public void setFingerprint(String fingerprint) {
+        this.fingerprint = fingerprint;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Set<DiscoveryCertificate> getDiscoveryCertificates() {
+        return discoveryCertificates;
+    }
+
+    public void setDiscoveryCertificates(Set<DiscoveryCertificate> discoveryCertificates) {
+        this.discoveryCertificates = discoveryCertificates;
+    }
+
+	public Certificate getCertificate() {
+		return certificate;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
+	public void setCertificate(Certificate certificate) {
+		this.certificate = certificate;
 	}
 
-	public String getFingerprint() {
-		return fingerprint;
-	}
-
-	public void setFingerprint(String fingerprint) {
-		this.fingerprint = fingerprint;
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	public void setContent(String content) {
-		this.content = content;
-	}
-	
 	@Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)

--- a/src/main/java/com/czertainly/core/dao/entity/DiscoveryCertificate.java
+++ b/src/main/java/com/czertainly/core/dao/entity/DiscoveryCertificate.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import java.io.Serializable;
@@ -37,14 +38,14 @@ public class DiscoveryCertificate extends UniquelyIdentifiedAndAudited implement
     @Column(name = "not_after")
     private Date notAfter;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "certificate_content_id", nullable = false, insertable = false, updatable = false)
     private CertificateContent certificateContent;
 
     @Column(name = "certificate_content_id", nullable = false)
-    private Long certificateContentId ;
+    private Long certificateContentId;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "discovery_uuid", nullable = false, insertable = false, updatable = false)
     private DiscoveryHistory discovery;
 
@@ -62,6 +63,14 @@ public class DiscoveryCertificate extends UniquelyIdentifiedAndAudited implement
         dto.setNotAfter(notAfter);
         dto.setCertificateContent(certificateContent.getContent());
         dto.setFingerprint(certificateContent.getFingerprint());
+        // Certificate Inventory UUID can be obtained from the content table since it has relation to the certificate.
+        // If the certificate is deleted from the inventory and the history is not deleted, then the content remains and
+        // the certificate becomes null. Also, the Certificate Content is unique for each certificate and the certificate
+        // inventory does not contain duplicate data. Hence, a single content will be mapped to a single certificate using
+        // One-to-One relation
+        if (certificateContent.getCertificate() != null) {
+            dto.setInventoryUuid(certificateContent.getCertificate().getUuid().toString());
+        }
         return dto;
     }
 

--- a/src/main/java/com/czertainly/core/dao/entity/RaProfile.java
+++ b/src/main/java/com/czertainly/core/dao/entity/RaProfile.java
@@ -36,7 +36,7 @@ public class RaProfile extends UniquelyIdentifiedAndAudited implements Serializa
 
     //    @Lob
     @Basic(fetch = FetchType.LAZY)
-    @Column(name = "attributes", length = 4096)
+    @Column(name = "attributes", length = Integer.MAX_VALUE)
     private String attributes;
 
     @ManyToOne


### PR DESCRIPTION
This PR contains the changes for the following:

1. Add the Certificate UUID from the inventory to the discovery certificate DTO
2. Fix one-to-one to many-to-one