### PR TITLE
Update cryptographic operation response and fix key details response

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/CryptographicOperationControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/CryptographicOperationControllerImpl.java
@@ -2,17 +2,9 @@ package com.czertainly.core.api.web;
 
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.interfaces.core.web.CryptographicOperationsController;
-import com.czertainly.api.model.client.cryptography.operations.CipherDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.RandomDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.SignDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.client.cryptography.operations.*;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
 import com.czertainly.api.model.connector.cryptography.enums.CryptographicAlgorithm;
-import com.czertainly.api.model.connector.cryptography.operations.DecryptDataResponseDto;
-import com.czertainly.api.model.connector.cryptography.operations.EncryptDataResponseDto;
-import com.czertainly.api.model.connector.cryptography.operations.RandomDataResponseDto;
-import com.czertainly.api.model.connector.cryptography.operations.SignDataResponseDto;
-import com.czertainly.api.model.connector.cryptography.operations.VerifyDataResponseDto;
 import com.czertainly.core.security.authz.SecuredParentUUID;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.service.CryptographicOperationService;

--- a/src/main/java/com/czertainly/core/dao/entity/Certificate.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Certificate.java
@@ -137,7 +137,7 @@ public class Certificate extends UniquelyIdentifiedAndAudited implements Seriali
     @Column(name = "csr", length = Integer.MAX_VALUE)
     private String csr;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "key_uuid", insertable = false, updatable = false)
     private CryptographicKey key;
 

--- a/src/main/java/com/czertainly/core/dao/entity/CryptographicKey.java
+++ b/src/main/java/com/czertainly/core/dao/entity/CryptographicKey.java
@@ -1,8 +1,10 @@
 package com.czertainly.core.dao.entity;
 
+import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.core.cryptography.key.KeyDetailDto;
 import com.czertainly.api.model.core.cryptography.key.KeyDto;
 import com.czertainly.api.model.core.cryptography.key.KeyItemDto;
+import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.DtoMapper;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
@@ -193,6 +195,9 @@ public class CryptographicKey extends UniquelyIdentifiedAndAudited implements Se
         dto.setTokenInstanceUuid(tokenInstanceReferenceUuid.toString());
         dto.setItems(getKeyItems());
         dto.setOwner(owner);
+        dto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(
+                AttributeDefinitionUtils.deserialize(attributes, DataAttribute.class)
+        ));
         if (group != null) {
             dto.setGroup(group.mapToDto());
         }

--- a/src/main/java/com/czertainly/core/dao/entity/CryptographicKeyItem.java
+++ b/src/main/java/com/czertainly/core/dao/entity/CryptographicKeyItem.java
@@ -209,7 +209,7 @@ public class CryptographicKeyItem extends UniquelyIdentified implements Serializ
         dto.setFormat(format);
         dto.setState(state);
         dto.setEnabled(enabled);
-        dto.setUsage(getUsage().stream().map(KeyUsage::getName).collect(Collectors.toList()));
+        dto.setUsage(getUsage());
         return dto;
     }
 }

--- a/src/main/java/com/czertainly/core/service/CryptographicOperationService.java
+++ b/src/main/java/com/czertainly/core/service/CryptographicOperationService.java
@@ -3,13 +3,9 @@ package com.czertainly.core.service;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.model.client.attribute.RequestAttributeDto;
-import com.czertainly.api.model.client.cryptography.operations.CipherDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.RandomDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.SignDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.client.cryptography.operations.*;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
 import com.czertainly.api.model.connector.cryptography.enums.CryptographicAlgorithm;
-import com.czertainly.api.model.connector.cryptography.operations.*;
 import com.czertainly.core.security.authz.SecuredParentUUID;
 import com.czertainly.core.security.authz.SecuredUUID;
 

--- a/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -324,6 +324,8 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
         if (authorityInstanceRef.getConnector() != null) {
             try {
                 authorityInstanceApiClient.removeAuthorityInstance(authorityInstanceRef.getConnector().mapToDto(), authorityInstanceRef.getAuthorityInstanceUuid());
+            } catch (NotFoundException notFoundException) {
+                logger.warn("Authority is already deleted in the connector. Proceeding to remove it from the core");
             } catch (Exception e) {
                 logger.error(e.getMessage());
                 throw new ValidationException(e.getMessage());

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -675,13 +675,12 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public void clearKeyAssociations(UUID keyUuid) {
-        certificateRepository.findByKeyUuid(keyUuid)
-                .forEach(
-                        e ->
-                        {
-                            e.setKey(null);
-                            certificateRepository.save(e);
-                        });
+        List<Certificate> certificates = certificateRepository.findByKeyUuid(keyUuid);
+        for(Certificate certificate: certificates) {
+            certificate.setKey(null);
+            certificate.setKeyUuid(null);
+            certificateRepository.save(certificate);
+        }
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/service/impl/CryptographicOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicOperationServiceImpl.java
@@ -16,6 +16,7 @@ import com.czertainly.api.model.core.audit.OperationType;
 import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.api.model.core.cryptography.key.KeyEvent;
 import com.czertainly.api.model.core.cryptography.key.KeyEventStatus;
+import com.czertainly.api.model.core.cryptography.key.KeyUsage;
 import com.czertainly.core.aop.AuditLogged;
 import com.czertainly.core.attribute.EcdsaSignatureAttributes;
 import com.czertainly.core.attribute.RsaSignatureAttributes;
@@ -134,6 +135,13 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
         if (request.getCipherData() == null) {
             throw new ValidationException(ValidationError.create("Cannot encrypt null data"));
         }
+        if(!key.getUsage().contains(KeyUsage.SIGN) && !key.getCryptographicKey().getTokenProfile().getUsage().contains(KeyUsage.SIGN)) {
+            throw new ValidationException(
+                    ValidationError.create(
+                            "Key Usage of the certificate does not support encryption"
+                    )
+            );
+        }
         com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto requestDto = new com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto();
         requestDto.setCipherData(request.getCipherData().stream().map(e -> {
                             CipherRequestData cipherRequestData = new CipherRequestData();
@@ -181,6 +189,13 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
         logger.debug("Key details: {}", key);
         if (request.getCipherData() == null) {
             throw new ValidationException(ValidationError.create("Cannot decrypt null data"));
+        }
+        if(!key.getUsage().contains(KeyUsage.SIGN) && !key.getCryptographicKey().getTokenProfile().getUsage().contains(KeyUsage.SIGN)) {
+            throw new ValidationException(
+                    ValidationError.create(
+                            "Key Usage of the certificate does not support decryption"
+                    )
+            );
         }
         com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto requestDto = new com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto();
         requestDto.setCipherData(request.getCipherData().stream().map(e -> {
@@ -240,6 +255,13 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
         if (request.getData() == null) {
             throw new ValidationException(ValidationError.create("Cannot sign empty data"));
         }
+        if(!key.getUsage().contains(KeyUsage.SIGN) && !key.getCryptographicKey().getTokenProfile().getUsage().contains(KeyUsage.SIGN)) {
+            throw new ValidationException(
+                    ValidationError.create(
+                            "Key Usage of the certificate does not support signing"
+                    )
+            );
+        }
         validateSignatureAttributes(key.getCryptographicAlgorithm(), request.getSignatureAttributes());
         com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto requestDto = new com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto();
         requestDto.setSignatureAttributes(request.getSignatureAttributes());
@@ -289,6 +311,13 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
             throw new ValidationException(ValidationError.create("Cannot verify empty data"));
         }
         validateSignatureAttributes(key.getCryptographicAlgorithm(), request.getSignatureAttributes());
+        if(!key.getUsage().contains(KeyUsage.VERIFY) && !key.getCryptographicKey().getTokenProfile().getUsage().contains(KeyUsage.VERIFY)) {
+            throw new ValidationException(
+                    ValidationError.create(
+                            "Key Usage of the certificate does not support verification"
+                    )
+            );
+        }
         com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto requestDto = new com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto();
         requestDto.setSignatureAttributes(request.getSignatureAttributes());
         if (request.getData() != null) requestDto.setData(request.getData().stream().map(e -> {

--- a/src/main/java/com/czertainly/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/TokenProfileServiceImpl.java
@@ -334,7 +334,7 @@ public class TokenProfileServiceImpl implements TokenProfileService {
         entity.setTokenInstanceName(tokenInstanceReference.getName());
         entity.setTokenInstanceReference(tokenInstanceReference);
         entity.setTokenInstanceReferenceUuid(tokenInstanceReference.getUuid());
-        entity.setUsage(request.getUsage());
+        if(request.getUsage() != null) entity.setUsage(request.getUsage());
         return entity;
     }
 

--- a/src/main/java/com/czertainly/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/TokenProfileServiceImpl.java
@@ -334,6 +334,7 @@ public class TokenProfileServiceImpl implements TokenProfileService {
         entity.setTokenInstanceName(tokenInstanceReference.getName());
         entity.setTokenInstanceReference(tokenInstanceReference);
         entity.setTokenInstanceReferenceUuid(tokenInstanceReference.getUuid());
+        entity.setUsage(request.getUsage());
         return entity;
     }
 
@@ -343,6 +344,7 @@ public class TokenProfileServiceImpl implements TokenProfileService {
         entity.setTokenInstanceReference(tokenInstanceReference);
         if (request.getEnabled() != null) entity.setEnabled(request.getEnabled() != null && request.getEnabled());
         entity.setTokenInstanceName(tokenInstanceReference.getName());
+        if(request.getUsage() != null) entity.setUsage(request.getUsage());
         return entity;
     }
 

--- a/src/test/java/com/czertainly/core/service/CryptographicOperationServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CryptographicOperationServiceTest.java
@@ -4,15 +4,11 @@ import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.client.attribute.RequestAttributeDto;
-import com.czertainly.api.model.client.cryptography.operations.CipherDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.SignDataRequestDto;
-import com.czertainly.api.model.client.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.client.cryptography.operations.*;
 import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContent;
 import com.czertainly.api.model.connector.cryptography.enums.CryptographicAlgorithm;
 import com.czertainly.api.model.connector.cryptography.enums.KeyFormat;
 import com.czertainly.api.model.connector.cryptography.enums.KeyType;
-import com.czertainly.api.model.connector.cryptography.operations.data.CipherRequestData;
-import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
 import com.czertainly.api.model.core.cryptography.key.KeyState;
@@ -28,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -256,7 +254,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
     public void testEncrypt() throws ConnectorException {
         CipherRequestData data = new CipherRequestData();
         data.setIdentifier("identifier");
-        data.setData("Hello World!".getBytes());
+        data.setData(Base64.getEncoder().encodeToString("Hello World!".getBytes(StandardCharsets.UTF_8)));
 
         CipherDataRequestDto requestDto = new CipherDataRequestDto();
         requestDto.setCipherData(List.of(data));
@@ -268,7 +266,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
                                 "/v1/cryptographyProvider/tokens/[^/]+/keys/[^/]+/encrypt"
                         )
                 )
-                .willReturn(WireMock.ok()));
+                .willReturn(WireMock.okJson("{}")));
 
         cryptographicOperationService.encryptData(
                 tokenInstanceReference.getSecuredParentUuid(),
@@ -311,7 +309,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
     public void testDecrypt() throws ConnectorException {
         CipherRequestData data = new CipherRequestData();
         data.setIdentifier("identifier");
-        data.setData("Hello World!".getBytes());
+        data.setData(Base64.getEncoder().encodeToString("Hello World!".getBytes(StandardCharsets.UTF_8)));
 
         CipherDataRequestDto requestDto = new CipherDataRequestDto();
         requestDto.setCipherData(List.of(data));
@@ -323,7 +321,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
                                 "/v1/cryptographyProvider/tokens/[^/]+/keys/[^/]+/decrypt"
                         )
                 )
-                .willReturn(WireMock.ok()));
+                .willReturn(WireMock.okJson("{}")));
 
         cryptographicOperationService.decryptData(
                 tokenInstanceReference.getSecuredParentUuid(),
@@ -366,7 +364,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
     public void testSign_RSA() throws ConnectorException {
         SignatureRequestData data = new SignatureRequestData();
         data.setIdentifier("identifier");
-        data.setData("Hello World!".getBytes());
+        data.setData(Base64.getEncoder().encodeToString("Hello World!".getBytes(StandardCharsets.UTF_8)));
 
         SignDataRequestDto requestDto = new SignDataRequestDto();
         requestDto.setData(List.of(data));
@@ -384,7 +382,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
 
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/[^/]+/sign"))
-                .willReturn(WireMock.ok()));
+                .willReturn(WireMock.okJson("{}")));
 
         cryptographicOperationService.signData(
                 tokenInstanceReference.getSecuredParentUuid(),
@@ -427,7 +425,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
     public void testVerify() throws ConnectorException {
         SignatureRequestData data = new SignatureRequestData();
         data.setIdentifier("identifier");
-        data.setData("Hello World!".getBytes());
+        data.setData(Base64.getEncoder().encodeToString("Hello World!".getBytes(StandardCharsets.UTF_8)));
 
         VerifyDataRequestDto requestDto = new VerifyDataRequestDto();
         requestDto.setData(List.of(data));
@@ -445,7 +443,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
         requestDto.setSignatureAttributes(List.of(reqDto1, reqDto2));
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/[^/]+/verify"))
-                .willReturn(WireMock.ok()));
+                .willReturn(WireMock.okJson("{}")));
 
         cryptographicOperationService.verifyData(
                 tokenInstanceReference.getSecuredParentUuid(),

--- a/src/test/java/com/czertainly/core/service/CryptographicOperationServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CryptographicOperationServiceTest.java
@@ -12,6 +12,7 @@ import com.czertainly.api.model.connector.cryptography.enums.KeyType;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
 import com.czertainly.api.model.core.cryptography.key.KeyState;
+import com.czertainly.api.model.core.cryptography.key.KeyUsage;
 import com.czertainly.core.dao.entity.*;
 import com.czertainly.core.dao.repository.*;
 import com.czertainly.core.util.BaseSpringBootTest;
@@ -129,6 +130,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
         content.setState(KeyState.ACTIVE);
         content.setEnabled(true);
         content.setCryptographicAlgorithm(CryptographicAlgorithm.RSA);
+        content.setUsage(List.of(KeyUsage.SIGN, KeyUsage.ENCRYPT, KeyUsage.VERIFY, KeyUsage.DECRYPT));
         cryptographicKeyItemRepository.save(content);
 
         content1 = new CryptographicKeyItem();
@@ -141,6 +143,7 @@ public class CryptographicOperationServiceTest extends BaseSpringBootTest {
         content1.setState(KeyState.ACTIVE);
         content1.setEnabled(true);
         content1.setCryptographicAlgorithm(CryptographicAlgorithm.RSA);
+        content1.setUsage(List.of(KeyUsage.SIGN, KeyUsage.ENCRYPT, KeyUsage.VERIFY, KeyUsage.DECRYPT));
         cryptographicKeyItemRepository.save(content1);
 
         content.setKeyReferenceUuid(content.getUuid());


### PR DESCRIPTION
This PR contains the changes for the following:
1. Change byte array to base64 encoded string before sending the response through API
2. Fix discrepancies related to cryptographic operations and cryptographic keys related response and request DTO