### PR TITLE
Fix certificate push and delete from location

### DIFF
--- a/src/main/java/com/czertainly/core/service/AttributeService.java
+++ b/src/main/java/com/czertainly/core/service/AttributeService.java
@@ -211,6 +211,17 @@ public interface AttributeService {
     void deleteAttributeContent(UUID objectUuid, Resource resource);
 
     /**
+     * Function to delete all the attribute content for an individual object with the parent resource.
+     *
+     * @param objectUuid UUID of the object
+     * @param resource   Resource type
+     * @param parentObjectUuid Parent Object UUID
+     * @param parentResource Parent Object resource
+     * @param type Type of the attribute to be deleted. Either Custom or Metadata
+     */
+    void deleteAttributeContent(UUID objectUuid, Resource resource, UUID parentObjectUuid, Resource parentResource, AttributeType type);
+
+    /**
      * Function to get the list of custom attributes associated with a specific object
      *
      * @param uuid     UUID of the object

--- a/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
@@ -338,6 +338,20 @@ public class AttributeServiceImpl implements AttributeService {
     }
 
     @Override
+    public void deleteAttributeContent(UUID objectUuid, Resource resource, UUID parentObjectUuid, Resource parentResource, AttributeType type) {
+        logger.info("Deleting the attribute content for: {} with UUID: {}, Parent UUID: {}, Parent Resource: {}", resource, objectUuid, parentObjectUuid, parentResource);
+        for (AttributeContent2Object object : attributeContent2ObjectRepository.findByObjectUuidAndObjectTypeAndSourceObjectUuidAndSourceObjectType(objectUuid, resource, parentObjectUuid, parentResource)) {
+            AttributeDefinition definition = object.getAttributeContent().getAttributeDefinition();
+            if (definition.getType().equals(type)) {
+                attributeContent2ObjectRepository.delete(object);
+                if (attributeContent2ObjectRepository.findByAttributeContent(object.getAttributeContent()).size() == 0) {
+                    attributeContentRepository.delete(object.getAttributeContent());
+                }
+            }
+        }
+    }
+
+    @Override
     public List<ResponseAttributeDto> getCustomAttributesWithValues(UUID uuid, Resource resource) {
         logger.info("Getting the custom attributes for {} with UUID: {}", resource.getCode(), uuid);
         List<CustomAttribute> attributes = new ArrayList<>();


### PR DESCRIPTION
This PR contains the changes for the following:

1. When the certificate is set for the location, the metadata should be added to the certificates before it can be set to the location
2. Remove mask secrets from the location service implementation
closes #267 