### PR TITLE
Fix updating and deleting custom atttributes content for objects

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/CryptographicKeyItem.java
+++ b/src/main/java/com/czertainly/core/dao/entity/CryptographicKeyItem.java
@@ -162,6 +162,11 @@ public class CryptographicKeyItem extends UniquelyIdentified implements Serializ
     }
 
     public void setUsage(List<KeyUsage> usage) {
+        if(usage == null || usage.size() == 0) {
+            this.usage = null;
+            return;
+        }
+
         this.usage = String.join(
                 ",",
                 usage.stream().map(

--- a/src/main/java/com/czertainly/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -1,5 +1,6 @@
 package com.czertainly.core.dao.repository;
 
+import com.czertainly.api.model.common.attribute.v2.AttributeType;
 import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.core.dao.entity.AttributeContent;
 import com.czertainly.core.dao.entity.AttributeContent2Object;
@@ -16,6 +17,8 @@ import java.util.UUID;
 public interface AttributeContent2ObjectRepository extends JpaRepository<AttributeContent2Object, String> {
 
     List<AttributeContent2Object> findByObjectUuidAndObjectType(UUID uuid, Resource resource);
+
+    List<AttributeContent2Object> findByObjectUuidAndObjectTypeAndAttributeContentAttributeDefinitionType(UUID uuid, Resource resource, AttributeType attributeType);
 
     List<AttributeContent2Object> findByObjectUuidAndObjectTypeAndSourceObjectUuidAndSourceObjectType(UUID uuid, Resource resource, UUID sourceObjectUUid, Resource sourceObjectType);
 

--- a/src/main/java/com/czertainly/core/dao/repository/AttributeContentRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/AttributeContentRepository.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 @Transactional
@@ -17,5 +18,6 @@ public interface AttributeContentRepository extends JpaRepository<AttributeConte
     Optional<AttributeContent> findByAttributeContentAndAttributeDefinition(String serializedContent, AttributeDefinition definition);
 
     List<AttributeContent> findByAttributeDefinition(AttributeDefinition definition);
+//    List<AttributeContent> findByAttributeDefinitionUuid(UUID attributeDefinitionUuid);
 
 }

--- a/src/main/java/com/czertainly/core/service/DiscoveryService.java
+++ b/src/main/java/com/czertainly/core/service/DiscoveryService.java
@@ -12,7 +12,7 @@ import com.czertainly.core.security.authz.SecurityFilter;
 
 import java.util.List;
 
-public interface DiscoveryService {
+public interface DiscoveryService extends ResourceExtensionService {
 
     List<DiscoveryHistoryDto> listDiscoveries(SecurityFilter filter);
     DiscoveryHistoryDetailDto getDiscovery(SecuredUUID uuid) throws NotFoundException;

--- a/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
@@ -280,11 +280,19 @@ public class AttributeServiceImpl implements AttributeService {
 
     @Override
     public void updateAttributeContent(UUID objectUuid, UUID attributeUuid, List<BaseAttributeContent> attributeContent, Resource resource) throws NotFoundException {
+//        List<AttributeContent2Object> attributeContent2Objects = attributeContent2ObjectRepository
+//                .findByObjectUuidAndObjectType(
+//                        objectUuid,
+//                        resource
+//                );
+
         List<AttributeContent2Object> attributeContent2Objects = attributeContent2ObjectRepository
-                .findByObjectUuidAndObjectType(
+                .findByObjectUuidAndObjectTypeAndAttributeContentAttributeDefinitionType(
                         objectUuid,
-                        resource
+                        resource,
+                        AttributeType.CUSTOM
                 );
+
         if (attributeContent != null && (attributeContent2Objects == null || attributeContent2Objects.isEmpty())) {
             AttributeDefinition attributeDefinition = getAttributeDefinition(SecuredUUID.fromUUID(attributeUuid), AttributeType.CUSTOM);
             createAttributeContent(objectUuid, attributeDefinition.getAttributeName(), attributeContent, resource);
@@ -292,10 +300,10 @@ public class AttributeServiceImpl implements AttributeService {
         }
         for (AttributeContent2Object attributeContent2Object : attributeContent2Objects) {
             AttributeDefinition attributeDefinition = attributeContent2Object.getAttributeContent().getAttributeDefinition();
-            if (attributeDefinition.getType().equals(AttributeType.CUSTOM) && attributeDefinition.getAttributeUuid().equals(attributeUuid)) {
+            if (attributeDefinition.getAttributeUuid().equals(attributeUuid)) {
                 AttributeContent content = attributeContent2Object.getAttributeContent();
                 attributeContent2ObjectRepository.delete(attributeContent2Object);
-                if (attributeContent2ObjectRepository.countByAttributeContent(attributeContent2Object.getAttributeContent()) <= 1) {
+                if (attributeContent2ObjectRepository.countByAttributeContent(attributeContent2Object.getAttributeContent()) == 0) {
                     attributeContentRepository.delete(content);
                 }
                 if (attributeContent != null) {

--- a/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
@@ -696,6 +696,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyService {
         content.setKeyReferenceUuid(UUID.fromString(referenceUuid));
         content.setState(KeyState.ACTIVE);
         content.setEnabled(false);
+        if (cryptographicKey.getTokenProfile() != null) content.setUsage(cryptographicKey.getTokenProfile().getUsage());
         cryptographicKeyItemRepository.save(content);
         String message;
         if (isDiscovered) {

--- a/src/main/java/com/czertainly/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/DiscoveryServiceImpl.java
@@ -5,6 +5,7 @@ import com.czertainly.api.exception.*;
 import com.czertainly.api.model.client.discovery.DiscoveryDto;
 import com.czertainly.api.model.client.discovery.DiscoveryHistoryDetailDto;
 import com.czertainly.api.model.client.discovery.DiscoveryHistoryDto;
+import com.czertainly.api.model.common.NameAndUuidDto;
 import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.common.attribute.v2.MetadataAttribute;
 import com.czertainly.api.model.connector.discovery.DiscoveryDataRequestDto;
@@ -99,7 +100,7 @@ public class DiscoveryServiceImpl implements DiscoveryService {
     }
 
     public DiscoveryHistory getDiscoveryEntity(SecuredUUID uuid) throws NotFoundException {
-        return discoveryRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(Connector.class, uuid));
+        return discoveryRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(DiscoveryHistory.class, uuid));
     }
 
     @Override
@@ -365,5 +366,16 @@ public class DiscoveryServiceImpl implements DiscoveryService {
     private void updateMeta(Certificate modal, DiscoveryProviderCertificateDataDto certificate, DiscoveryHistory history) {
         metadataService.createMetadataDefinitions(history.getConnectorUuid(), certificate.getMeta());
         metadataService.createMetadata(history.getConnectorUuid(), modal.getUuid(), history.getUuid(), history.getName(), certificate.getMeta(), Resource.CERTIFICATE, Resource.DISCOVERY);
+    }
+
+    @Override
+    public List<NameAndUuidDto> listResourceObjects(SecurityFilter filter) {
+        return null;
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.GROUP, action = ResourceAction.UPDATE)
+    public void evaluatePermissionChain(SecuredUUID uuid) throws NotFoundException {
+        getDiscoveryEntity(uuid);
     }
 }

--- a/src/main/java/com/czertainly/core/service/impl/ResourceServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ResourceServiceImpl.java
@@ -29,6 +29,7 @@ public class ResourceServiceImpl implements ResourceService {
     private ComplianceProfileService complianceProfileService;
     private ConnectorService connectorService;
     private CredentialService credentialService;
+    private DiscoveryService discoveryService;
     private EntityInstanceService entityInstanceService;
     private GroupService groupService;
     private RaProfileService raProfileService;
@@ -63,6 +64,11 @@ public class ResourceServiceImpl implements ResourceService {
     @Autowired
     public void setCredentialService(CredentialService credentialService) {
         this.credentialService = credentialService;
+    }
+
+    @Autowired
+    public void setDiscoveryService(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
     }
 
     @Autowired
@@ -168,6 +174,9 @@ public class ResourceServiceImpl implements ResourceService {
                 break;
             case CREDENTIAL:
                 credentialService.evaluatePermissionChain(objectUuid);
+                break;
+            case DISCOVERY:
+                discoveryService.evaluatePermissionChain(objectUuid);
                 break;
             case ENTITY:
                 entityInstanceService.evaluatePermissionChain(objectUuid);

--- a/src/main/java/com/czertainly/core/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/StatisticsServiceImpl.java
@@ -57,7 +57,7 @@ public class StatisticsServiceImpl implements StatisticsService {
         try {
             dto.setTotalRaProfiles(raProfileService.statisticsRaProfilesCount(SecurityFilter.create()));
         } catch (AccessDeniedException e){
-            dto.setTotalGroups(0L);
+            dto.setTotalRaProfiles(0L);
         }
         return certificateService.addCertificateStatistics(SecurityFilter.create(), dto);
     }

--- a/src/test/java/com/czertainly/core/service/CustomAttributeServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CustomAttributeServiceTest.java
@@ -252,7 +252,7 @@ public class CustomAttributeServiceTest extends BaseSpringBootTest {
 
     @Test
     public void testUpdateResourceFailure() throws ValidationException, NotFoundException {
-        Assertions.assertThrows(ValidationException.class, () -> attributeService.updateResources(SecuredUUID.fromUUID(definition.getUuid()), List.of(Resource.DASHBOARD)));
+        Assertions.assertThrows(ValidationException.class, () -> attributeService.updateResources(SecuredUUID.fromUUID(definition.getUuid()), List.of(Resource.AUDIT_LOG)));
     }
 
     @Test


### PR DESCRIPTION
- fix deleting when content does not have any objects having that content
- fix updating content when object has other than custom attributes content (metadata)
- fix missing support for updating custom attributes content for discoveries