### PR TITLE
Fix custom attribute validation for ACME

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/CryptographicKeyControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/CryptographicKeyControllerImpl.java
@@ -46,6 +46,11 @@ public class CryptographicKeyControllerImpl implements CryptographicKeyControlle
     }
 
     @Override
+    public List<KeyDto> listKeyPairs(Optional<String> tokenProfileUuid) {
+        return cryptographicKeyService.listKeyPairs(tokenProfileUuid, SecurityFilter.create());
+    }
+
+    @Override
     public KeyDetailDto getKey(String tokenInstanceUuid, String uuid) throws NotFoundException {
         return cryptographicKeyService.getKey(
                 SecuredParentUUID.fromString(tokenInstanceUuid),

--- a/src/main/java/com/czertainly/core/dao/entity/AttributeDefinition.java
+++ b/src/main/java/com/czertainly/core/dao/entity/AttributeDefinition.java
@@ -36,7 +36,7 @@ public class AttributeDefinition extends UniquelyIdentifiedAndAudited {
     @Column(name = "attribute_name")
     private String attributeName;
 
-    @Column(name = "attribute_definition", columnDefinition="TEXT")
+    @Column(name = "attribute_definition", columnDefinition = "TEXT")
     private String attributeDefinition;
 
     @Column(name = "attribute_type")
@@ -64,7 +64,7 @@ public class AttributeDefinition extends UniquelyIdentifiedAndAudited {
 
     public void setConnector(Connector connector) {
         this.connector = connector;
-        this.connectorUuid = connector.getUuid();
+        if (connector != null) this.connectorUuid = connector.getUuid();
     }
 
     public UUID getConnectorUuid() {

--- a/src/main/java/com/czertainly/core/dao/entity/Connector.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Connector.java
@@ -63,6 +63,14 @@ public class Connector extends UniquelyIdentifiedAndAudited implements Serializa
     @JsonIgnore
     private Set<TokenInstanceReference> tokenInstanceReferences = new HashSet<>();
 
+    @OneToMany(mappedBy = "connectorUuid")
+    @JsonIgnore
+    private Set<AttributeDefinition> attributeDefinitions = new HashSet<>();
+
+    @OneToMany(mappedBy = "connectorUuid")
+    @JsonIgnore
+    private Set<AttributeContent2Object> attributeContent2Objects = new HashSet<>();
+
     public String getName() {
         return name;
     }
@@ -133,6 +141,14 @@ public class Connector extends UniquelyIdentifiedAndAudited implements Serializa
 
     public Set<TokenInstanceReference> getTokenInstanceReferences() {
         return tokenInstanceReferences;
+    }
+
+    public Set<AttributeDefinition> getAttributeDefinitions() {
+        return attributeDefinitions;
+    }
+
+    public Set<AttributeContent2Object> getAttributeContent2Objects() {
+        return attributeContent2Objects;
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -1,6 +1,5 @@
 package com.czertainly.core.dao.repository;
 
-import com.czertainly.api.model.common.attribute.v2.AttributeType;
 import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.core.dao.entity.AttributeContent;
 import com.czertainly.core.dao.entity.AttributeContent2Object;
@@ -9,7 +8,6 @@ import org.springframework.stereotype.Repository;
 
 import jakarta.transaction.Transactional;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -17,6 +15,8 @@ import java.util.UUID;
 public interface AttributeContent2ObjectRepository extends JpaRepository<AttributeContent2Object, String> {
 
     List<AttributeContent2Object> findByObjectUuidAndObjectType(UUID uuid, Resource resource);
+
+    List<AttributeContent2Object> findByObjectUuidAndObjectTypeOrderByAttributeContentAttributeDefinitionAttributeName(UUID uuid, Resource resource);
 
     List<AttributeContent2Object> findByObjectUuidAndObjectTypeAndAttributeContentAttributeDefinitionUuid(UUID uuid, Resource resource, UUID attributeDefinitionUuid);
 

--- a/src/main/java/com/czertainly/core/service/AttributeService.java
+++ b/src/main/java/com/czertainly/core/service/AttributeService.java
@@ -259,4 +259,5 @@ public interface AttributeService {
      * attribute available for the given attribute uuid and the connector UUID
      */
     DataAttribute getReferenceAttribute(UUID connectorUUid, String attributeName);
+
 }

--- a/src/main/java/com/czertainly/core/service/CryptographicKeyService.java
+++ b/src/main/java/com/czertainly/core/service/CryptographicKeyService.java
@@ -28,6 +28,15 @@ public interface CryptographicKeyService extends ResourceExtensionService  {
     List<KeyDto> listKeys(Optional<String> tokenInstanceUuid, SecurityFilter filter);
 
     /**
+     * List of all available keys that contains full key pair
+     *
+     * @param tokenInstanceUuid UUID of the token instance
+     * @param filter            Security Filter for Access Control
+     * @return List of Key details {@Link KeyDto}
+     */
+    List<KeyDto> listKeyPairs(Optional<String> tokenInstanceUuid, SecurityFilter filter);
+
+    /**
      * @param tokenInstanceUuid UUID of the token instance
      * @param uuid              UUID of the concerned Key
      * @return Detail of the key {@Link KeyDetailDto}

--- a/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
@@ -359,7 +359,7 @@ public class AttributeServiceImpl implements AttributeService {
     public List<ResponseAttributeDto> getCustomAttributesWithValues(UUID uuid, Resource resource) {
         logger.info("Getting the custom attributes for {} with UUID: {}", resource.getCode(), uuid);
         List<CustomAttribute> attributes = new ArrayList<>();
-        for (AttributeContent2Object object : attributeContent2ObjectRepository.findByObjectUuidAndObjectType(uuid, resource)) {
+        for (AttributeContent2Object object : attributeContent2ObjectRepository.findByObjectUuidAndObjectTypeOrderByAttributeContentAttributeDefinitionAttributeName(uuid, resource)) {
             AttributeDefinition definition = object.getAttributeContent().getAttributeDefinition();
             if (definition.getType().equals(AttributeType.CUSTOM) && definition.isEnabled()) {
                 CustomAttribute attribute = object.getAttributeContent().getAttributeDefinition().getAttributeDefinition(CustomAttribute.class);

--- a/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
@@ -461,6 +461,15 @@ public class AttributeServiceImpl implements AttributeService {
         logger.info("Creating the attribute content for: {} with UUID: {}", resource, objectUuid);
         String serializedContent = AttributeDefinitionUtils.serializeAttributeContent(value);
         AttributeDefinition definition = attributeDefinitionRepository.findByTypeAndAttributeName(AttributeType.CUSTOM, attributeName).orElse(null);
+        List<ValidationError> validationErrors = new ArrayList<>();
+        AttributeDefinitionUtils.validateAttributeContent(
+                definition.getAttributeDefinition(CustomAttribute.class),
+                value,
+                validationErrors
+        );
+        if(!validationErrors.isEmpty()) {
+            throw new ValidationException(validationErrors);
+        }
         if (!definition.isEnabled()) {
             logger.warn("Attribute {} is disabled and the content will not be created");
             return;

--- a/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
@@ -1098,7 +1098,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyService {
         content.setReason(reason);
         cryptographicKeyItemRepository.save(content);
         keyEventHistoryService.addEventHistory(KeyEvent.COMPROMISED, KeyEventStatus.SUCCESS,
-                "Compromised Key", null, content);
+                "Compromised Key. Reason: " + reason, null, content);
     }
 
     /**

--- a/src/main/java/com/czertainly/core/service/impl/CryptographicOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicOperationServiceImpl.java
@@ -447,15 +447,13 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
                 //do nothing
             }
         }
-        List.of(privateKeyItem, publicKeyItem).forEach(e -> {
-            if (e == null) {
-                throw new ValidationException(
-                        ValidationError.create(
-                                "Selected item does not contain the complete keypair"
-                        )
-                );
-            }
-        });
+        if (privateKeyItem == null || publicKeyItem == null) {
+            throw new ValidationException(
+                    ValidationError.create(
+                            "Selected item does not contain the complete keypair"
+                    )
+            );
+        }
 
         // Generate the CSR
         return generateCsr(

--- a/src/main/java/com/czertainly/core/service/impl/MetadataServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/MetadataServiceImpl.java
@@ -86,7 +86,7 @@ public class MetadataServiceImpl implements MetadataService {
     public List<MetadataAttribute> getMetadata(UUID connectorUuid, UUID uuid, Resource resource) {
         List<MetadataAttribute> metadata = new ArrayList<>();
         for (AttributeContent2Object object : metadata2ObjectRepository.findByObjectUuidAndObjectType(uuid, resource)) {
-            if (object.getAttributeContent().getAttributeDefinition().getConnectorUuid().equals(connectorUuid)) {
+            if (object.getAttributeContent().getAttributeDefinition().getConnectorUuid() == null || object.getAttributeContent().getAttributeDefinition().getConnectorUuid().equals(connectorUuid)) {
                 MetadataAttribute attribute = object.getAttributeContent().getAttributeDefinition().getAttributeDefinition(MetadataAttribute.class);
                 attribute.setContent(object.getAttributeContent().getAttributeContent(BaseAttributeContent.class));
                 metadata.add(attribute);
@@ -99,7 +99,7 @@ public class MetadataServiceImpl implements MetadataService {
     public List<MetadataAttribute> getMetadataWithSource(UUID connectorUuid, UUID uuid, Resource resource, UUID sourceObjectUuid, Resource sourceObjectResource) {
         List<MetadataAttribute> metadata = new ArrayList<>();
         for (AttributeContent2Object object : metadata2ObjectRepository.findByObjectUuidAndObjectTypeAndSourceObjectUuidAndSourceObjectType(uuid, resource, sourceObjectUuid, sourceObjectResource)) {
-            if (object.getAttributeContent().getAttributeDefinition().getConnectorUuid().equals(connectorUuid)) {
+            if (object.getAttributeContent().getAttributeDefinition().getConnectorUuid() == null || object.getAttributeContent().getAttributeDefinition().getConnectorUuid().equals(connectorUuid)) {
                 MetadataAttribute attribute = object.getAttributeContent().getAttributeDefinition().getAttributeDefinition(MetadataAttribute.class);
                 attribute.setContent(object.getAttributeContent().getAttributeContent(BaseAttributeContent.class));
                 metadata.add(attribute);


### PR DESCRIPTION
This PR contains the following changes:

1. Add ACME User check before validating the custom attributes for issuing certificates with client operations.

2. Add reason for revocation of certificate and key