### PR TITLE
Enable springboot actuator for health monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>

--- a/src/main/java/com/czertainly/core/auth/ResourceListener.java
+++ b/src/main/java/com/czertainly/core/auth/ResourceListener.java
@@ -28,7 +28,7 @@ public class ResourceListener {
         Map<Resource, String> listingEndpoints = new HashMap<>();
         Map<Resource, Set<String>> resourceToAction = new HashMap<>();
         //Get all the routes annotated with the listing end point
-        applicationContext.getBean(RequestMappingHandlerMapping.class)
+        applicationContext.getBean("requestMappingHandlerMapping", RequestMappingHandlerMapping.class)
                 .getHandlerMethods()
                 .entrySet().stream()
                 .filter(e -> !e.getKey().getMethodsCondition().getMethods().isEmpty())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,3 +60,8 @@ scheduled-tasks.enabled=${SCHEDULED_TASKS_ENABLED:true}
 
 # authentication through token
 auth.token.header-name=${AUTH_TOKEN_HEADER_NAME:X-USERINFO}
+
+# configuration of actuator
+management.endpoints.web.base-path=/
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
This PR contains the changes for the following:

1. Enable springboot actuator for health monitoring
2. Update ResourceListener to include requestMappingHandlerMapping while getting the content since there are two beans in the new springboot release