### PR TITLE
Add missing object access control for tokens and token profiles

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/TokenInstanceControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/TokenInstanceControllerImpl.java
@@ -8,8 +8,10 @@ import com.czertainly.api.interfaces.core.web.TokenInstanceController;
 import com.czertainly.api.model.client.attribute.RequestAttributeDto;
 import com.czertainly.api.model.client.cryptography.token.TokenInstanceRequestDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
+import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.api.model.core.cryptography.token.TokenInstanceDetailDto;
 import com.czertainly.api.model.core.cryptography.token.TokenInstanceDto;
+import com.czertainly.core.auth.AuthEndpoint;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
 import com.czertainly.core.service.TokenInstanceService;
@@ -30,6 +32,7 @@ public class TokenInstanceControllerImpl implements TokenInstanceController {
 
 
     @Override
+    @AuthEndpoint(resourceName = Resource.TOKEN)
     public List<TokenInstanceDto> listTokenInstances() {
         return tokenInstanceService.listTokenInstances(SecurityFilter.create());
     }

--- a/src/main/java/com/czertainly/core/api/web/TokenProfileControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/TokenProfileControllerImpl.java
@@ -11,8 +11,10 @@ import com.czertainly.api.model.client.cryptography.tokenprofile.AddTokenProfile
 import com.czertainly.api.model.client.cryptography.tokenprofile.BulkTokenProfileKeyUsageRequestDto;
 import com.czertainly.api.model.client.cryptography.tokenprofile.EditTokenProfileRequestDto;
 import com.czertainly.api.model.client.cryptography.tokenprofile.TokenProfileKeyUsageRequestDto;
+import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.api.model.core.cryptography.tokenprofile.TokenProfileDetailDto;
 import com.czertainly.api.model.core.cryptography.tokenprofile.TokenProfileDto;
+import com.czertainly.core.auth.AuthEndpoint;
 import com.czertainly.core.security.authz.SecuredParentUUID;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
@@ -38,6 +40,7 @@ public class TokenProfileControllerImpl implements TokenProfileController {
     }
 
     @Override
+    @AuthEndpoint(resourceName = Resource.TOKEN_PROFILE)
     public List<TokenProfileDto> listTokenProfiles(Optional<Boolean> enabled) {
         return tokenProfileService.listTokenProfiles(enabled, SecurityFilter.create());
     }


### PR DESCRIPTION
This PR contains the changes for the following:

1. Include @AuthEndPoint annotation of the token profiles and token controller implementations