### PR TITLE
Fix global metadata uuid in the DTO

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/AttributeDefinition.java
+++ b/src/main/java/com/czertainly/core/dao/entity/AttributeDefinition.java
@@ -170,7 +170,7 @@ public class AttributeDefinition extends UniquelyIdentifiedAndAudited {
             dto.setEnabled(enabled);
         } else if (type.equals(AttributeType.META)) {
             MetadataAttribute attribute = getAttributeDefinition(MetadataAttribute.class);
-            dto.setUuid(attribute.getUuid());
+            dto.setUuid(uuid.toString());
             dto.setName(attribute.getName());
             dto.setContentType(attribute.getContentType());
             dto.setDescription(attribute.getDescription());
@@ -206,7 +206,7 @@ public class AttributeDefinition extends UniquelyIdentifiedAndAudited {
     public GlobalMetadataDefinitionDetailDto mapToGlobalMetadataDefinitionDetailDto() {
         MetadataAttribute attribute = getAttributeDefinition(MetadataAttribute.class);
         GlobalMetadataDefinitionDetailDto dto = new GlobalMetadataDefinitionDetailDto();
-        dto.setUuid(attribute.getUuid());
+        dto.setUuid(uuid.toString());
         dto.setName(attribute.getName());
         dto.setType(AttributeType.META);
         dto.setContentType(attribute.getContentType());

--- a/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
@@ -393,12 +393,13 @@ public class AttributeServiceImpl implements AttributeService {
             if (definition.getAttributeName() == null || definition.getAttributeUuid() == null || definition.getConnectorUuid() == null) {
                 continue;
             }
-            GlobalMetadataDefinitionDetailDto metadataAttribute = definition.mapToGlobalMetadataDefinitionDetailDto();
+            MetadataAttribute attribute = definition.getAttributeDefinition(MetadataAttribute.class);
+            String label = attribute.getProperties() != null ? attribute.getProperties().getLabel() : null;
             ConnectorMetadataResponseDto dto = new ConnectorMetadataResponseDto();
-            dto.setName(metadataAttribute.getName());
-            dto.setUuid(metadataAttribute.getUuid());
-            dto.setContentType(metadataAttribute.getContentType());
-            dto.setLabel(metadataAttribute.getLabel());
+            dto.setName(definition.getAttributeName());
+            dto.setUuid(definition.getAttributeUuid().toString());
+            dto.setContentType(definition.getContentType());
+            dto.setLabel(label);
             dto.setConnectorUuid(definition.getConnectorUuid().toString());
             response.add(dto);
         }
@@ -462,7 +463,7 @@ public class AttributeServiceImpl implements AttributeService {
         String serializedContent = AttributeDefinitionUtils.serializeAttributeContent(value);
         AttributeDefinition definition = attributeDefinitionRepository.findByTypeAndAttributeName(AttributeType.CUSTOM, attributeName).orElse(null);
 
-        if(definition == null) {
+        if (definition == null) {
             logger.warn("Custom attribute with name '" + attributeName + "' does not exist");
             return;
         }
@@ -473,7 +474,7 @@ public class AttributeServiceImpl implements AttributeService {
                 value,
                 validationErrors
         );
-        if(!validationErrors.isEmpty()) {
+        if (!validationErrors.isEmpty()) {
             throw new ValidationException(validationErrors);
         }
         if (!definition.isEnabled()) {

--- a/src/test/java/com/czertainly/core/service/GlobalMetadataServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/GlobalMetadataServiceTest.java
@@ -142,7 +142,7 @@ public class GlobalMetadataServiceTest extends BaseSpringBootTest {
         Assertions.assertNotNull(metadata);
         Assertions.assertFalse(metadata.isEmpty());
         Assertions.assertEquals(1, metadata.size());
-        Assertions.assertEquals(metaAttribute.getUuid(), metadata.get(0).getUuid());
+        Assertions.assertEquals(metaDefinition.getUuid().toString(), metadata.get(0).getUuid());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class GlobalMetadataServiceTest extends BaseSpringBootTest {
         GlobalMetadataDefinitionDetailDto dto = attributeService.getGlobalMetadata(SecuredUUID.fromUUID(metaDefinition.getUuid()));
         Assertions.assertNotNull(dto);
         Assertions.assertFalse(dto.getUuid().isEmpty());
-        Assertions.assertEquals(metaAttribute.getUuid(), dto.getUuid());
+        Assertions.assertEquals(metaDefinition.getUuid().toString(), dto.getUuid());
         Assertions.assertEquals(metaAttribute.getName(), dto.getName());
         Assertions.assertEquals(metaAttribute.getType(), AttributeType.META);
         Assertions.assertEquals(metaAttribute.getContentType(), AttributeContentType.STRING);


### PR DESCRIPTION
This PR contains the changes for the following:

1. When the global metadata is listed, the UUID of the global metadata and the actual global metadata attribute UUID will be different in the database. This is to ensure that we do not have duplicates in the metadata across the connectors for global. But when the list is returned, instead of the UUID of the entry, the dto contains the uuid of the metadatattribute, which upon detail request will throw not found exception.

2. Update the test cases for the fix

3. Update connector metadata listing for promotion with the fix