### PR TITLE
Change delete of global metadata to demote

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/GlobalMetadataControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/GlobalMetadataControllerImpl.java
@@ -62,12 +62,12 @@ public class GlobalMetadataControllerImpl implements GlobalMetadataController {
 
     @Override
     public void deleteGlobalMetadata(String uuid) throws NotFoundException {
-        attributeService.deleteAttribute(SecuredUUID.fromString(uuid), AttributeType.META);
+        attributeService.demoteConnectorMetadata(SecuredUUID.fromString(uuid));
     }
 
     @Override
     public void bulkDeleteGlobalMetadata(List<String> metadataUuids) {
-        attributeService.bulkDeleteAttributes(SecuredUUID.fromList(metadataUuids), AttributeType.META);
+        attributeService.bulkDemoteConnectorMetadata(SecuredUUID.fromList(metadataUuids));
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/service/AttributeService.java
+++ b/src/main/java/com/czertainly/core/service/AttributeService.java
@@ -250,6 +250,19 @@ public interface AttributeService {
     GlobalMetadataDefinitionDetailDto promoteConnectorMetadata(UUID uuid, UUID connectorUUid) throws NotFoundException;
 
     /**
+     * Demote multiple global metadata
+     *
+     * @param attributeUuids UUIDs of the global metadata to be demoted
+     */
+    void bulkDemoteConnectorMetadata(List<SecuredUUID> attributeUuids);
+
+    /**
+     * Function to demote the metadata from global metadata to connector metadata as result of delete operation
+     * @param uuid    UUID of the global metadata
+     */
+    void demoteConnectorMetadata(SecuredUUID uuid) throws NotFoundException;
+
+    /**
      * Check and create the reference attributes in the database
      */
     AttributeDefinition createAttributeDefinition(UUID connectorUuid, BaseAttribute attribute);

--- a/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AttributeServiceImpl.java
@@ -407,7 +407,7 @@ public class AttributeServiceImpl implements AttributeService {
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.ATTRIBUTE, action = ResourceAction.DETAIL)
+    @ExternalAuthorization(resource = Resource.ATTRIBUTE, action = ResourceAction.UPDATE)
     public GlobalMetadataDefinitionDetailDto promoteConnectorMetadata(UUID uuid, UUID connectorUUid) throws NotFoundException {
         AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(
                 connectorUUid,
@@ -416,6 +416,26 @@ public class AttributeServiceImpl implements AttributeService {
         definition.setGlobal(true);
         attributeDefinitionRepository.save(definition);
         return getGlobalMetadata(SecuredUUID.fromUUID(definition.getUuid()));
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.ATTRIBUTE, action = ResourceAction.UPDATE)
+    public void demoteConnectorMetadata(SecuredUUID uuid) throws NotFoundException {
+        AttributeDefinition definition = getAttributeDefinition(uuid, AttributeType.META);
+        definition.setGlobal(false);
+        attributeDefinitionRepository.save(definition);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.ATTRIBUTE, action = ResourceAction.UPDATE)
+    public void bulkDemoteConnectorMetadata(List<SecuredUUID> attributeUuids) {
+        for (SecuredUUID uuid : attributeUuids) {
+            try {
+                demoteConnectorMetadata(uuid);
+            } catch (NotFoundException e) {
+                logger.warn("Unable to find global metadata with UUID {}", uuid);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
When global metadata was deleted, it was removed together with all content. Delete will now mark metadata as not global.