### PR TITLE
Create CSR without issuing the certificate and support certificate with New status

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/CertificateControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/CertificateControllerImpl.java
@@ -11,12 +11,14 @@ import com.czertainly.api.model.core.certificate.*;
 import com.czertainly.api.model.core.location.LocationDto;
 import com.czertainly.api.model.core.search.SearchFieldDataByGroupDto;
 import com.czertainly.api.model.core.search.SearchFieldDataDto;
+import com.czertainly.api.model.core.v2.ClientCertificateRequestDto;
 import com.czertainly.core.dao.entity.Certificate;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
 import com.czertainly.core.service.CertValidationService;
 import com.czertainly.core.service.CertificateEventHistoryService;
 import com.czertainly.core.service.CertificateService;
+import com.czertainly.core.service.v2.ClientOperationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,7 +28,9 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +47,9 @@ public class CertificateControllerImpl implements CertificateController {
 
 	@Autowired
 	private CertificateEventHistoryService certificateEventHistoryService;
+
+	@Autowired
+	private ClientOperationService clientOperationService;
 
 	@Override
 	public CertificateResponseDto listCertificates(SearchRequestDto request) throws ValidationException {
@@ -144,6 +151,11 @@ public class CertificateControllerImpl implements CertificateController {
 	@Override
 	public List<CertificateContentDto> getCertificateContent(List<String> uuids) {
 		return certificateService.getCertificateContent(uuids);
+	}
+
+	@Override
+	public CertificateDetailDto createCsr(ClientCertificateRequestDto request) throws ValidationException, NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException {
+		return clientOperationService.createCsr(request);
 	}
 
 }

--- a/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
@@ -34,6 +34,8 @@ public interface CertificateRepository extends SecurityFilterRepository<Certific
 
     List<Certificate> findBySubjectDn(String subjectDn);
 
+    List<Certificate> findByCommonName(String commonName);
+
     List<Certificate> findAllByIssuerSerialNumber(String issuerSerialNumber);
 
     List<Certificate> findByStatus(CertificateStatus status);

--- a/src/main/java/com/czertainly/core/service/CertificateService.java
+++ b/src/main/java/com/czertainly/core/service/CertificateService.java
@@ -22,7 +22,10 @@ import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
 
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -36,6 +39,10 @@ public interface CertificateService extends ResourceExtensionService  {
     CertificateDetailDto getCertificate(SecuredUUID uuid) throws NotFoundException, CertificateException, IOException;
 
     Certificate getCertificateEntity(SecuredUUID uuid) throws NotFoundException;
+
+    List<Certificate> getCertificateEntityBySubjectDn(String subjectDn);
+
+    List<Certificate> getCertificateEntityByCommonName(String commonName);
 
     // TODO AUTH - unable to check access based on certificate content. Make private? Special permission? Call opa in method?
     Certificate getCertificateEntityByContent(String content);
@@ -221,4 +228,23 @@ public interface CertificateService extends ResourceExtensionService  {
      * @return List of certificate contents
      */
     List<CertificateContentDto> getCertificateContent(List<String> uuids);
+
+    /**
+     * Create CSR Entity and store it in the database which is ready for issuing
+     * @param csr - PKCS10 certificate request to be added
+     * @param signatureAttributes signatureAttributes used to sign the CSR. If the CSR is uploaded from the User
+     *                            this parameter should be left empty
+     * @param csrAttributes Attributes used to create CSR
+     * @param keyUuid UUID of the key used to sign the CSR
+     */
+    Certificate createCsr(String csr, List<RequestAttributeDto> signatureAttributes, List<DataAttribute> csrAttributes, UUID keyUuid) throws IOException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException;
+
+    /**
+     * Function to change the Certificate Entity from CSR to Certificate
+     * @param uuid UUID of the entity to be transformed
+     * @param certificateData Issued Certificate Data
+     * @param meta Metadata of the certificate
+     * @return Certificate entity
+     */
+    Certificate updateCsrToCertificate(UUID uuid, String certificateData, List<MetadataAttribute> meta) throws AlreadyExistException, CertificateException, NoSuchAlgorithmException, NotFoundException;
 }

--- a/src/main/java/com/czertainly/core/service/v2/ClientOperationService.java
+++ b/src/main/java/com/czertainly/core/service/v2/ClientOperationService.java
@@ -1,16 +1,22 @@
 package com.czertainly.core.service.v2;
 
-import com.czertainly.api.exception.AlreadyExistException;
-import com.czertainly.api.exception.CertificateOperationException;
-import com.czertainly.api.exception.ConnectorException;
-import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.exception.*;
 import com.czertainly.api.model.client.attribute.RequestAttributeDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
+import com.czertainly.api.model.core.auth.Resource;
+import com.czertainly.api.model.core.certificate.CertificateDetailDto;
+import com.czertainly.api.model.core.certificate.CertificateDto;
 import com.czertainly.api.model.core.v2.*;
+import com.czertainly.core.dao.entity.Certificate;
+import com.czertainly.core.model.auth.ResourceAction;
+import com.czertainly.core.security.authz.ExternalAuthorization;
 import com.czertainly.core.security.authz.SecuredParentUUID;
 import com.czertainly.core.security.authz.SecuredUUID;
 
+import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.util.List;
 
@@ -18,23 +24,31 @@ public interface ClientOperationService {
 
     List<BaseAttribute> listIssueCertificateAttributes(
             SecuredParentUUID authorityUuid,
-            SecuredUUID raProfileUuid) throws ConnectorException;
+            SecuredUUID raProfileUuid
+    ) throws ConnectorException;
 
     boolean validateIssueCertificateAttributes(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
-            List<RequestAttributeDto> attributes) throws ConnectorException, ValidationException;
+            List<RequestAttributeDto> attributes
+    ) throws ConnectorException, ValidationException;
+
+    CertificateDetailDto createCsr(
+            ClientCertificateRequestDto request
+    ) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException;
 
     ClientCertificateDataResponseDto issueCertificate(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
-            ClientCertificateSignRequestDto request) throws ConnectorException, AlreadyExistException, CertificateException, NoSuchAlgorithmException;
+            ClientCertificateSignRequestDto request
+    ) throws ConnectorException, AlreadyExistException, CertificateException, NoSuchAlgorithmException;
 
     ClientCertificateDataResponseDto renewCertificate(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
             String certificateUuid,
-            ClientCertificateRenewRequestDto request) throws ConnectorException, AlreadyExistException, CertificateException, CertificateOperationException;
+            ClientCertificateRenewRequestDto request
+    ) throws ConnectorException, AlreadyExistException, CertificateException, CertificateOperationException;
 
     ClientCertificateDataResponseDto rekeyCertificate(
             SecuredParentUUID authorityUuid,
@@ -50,11 +64,13 @@ public interface ClientOperationService {
     boolean validateRevokeCertificateAttributes(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
-            List<RequestAttributeDto> attributes) throws ConnectorException, ValidationException;
+            List<RequestAttributeDto> attributes
+    ) throws ConnectorException, ValidationException;
 
     void revokeCertificate(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
             String certificateUuid,
-            ClientCertificateRevocationDto request) throws ConnectorException;
+            ClientCertificateRevocationDto request
+    ) throws ConnectorException;
 }

--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -247,6 +247,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
 
         Certificate oldCertificate = certificateService.getCertificateEntity(SecuredUUID.fromString(certificateUuid));
+        checkNewStatus(oldCertificate.getStatus());
         extendedAttributeService.validateLegacyConnector(raProfile.getAuthorityInstanceReference().getConnector());
         logger.debug("Renewing Certificate: ", oldCertificate.toString());
         CertificateRenewRequestDto caRequest = new CertificateRenewRequestDto();
@@ -351,6 +352,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
 
         Certificate oldCertificate = certificateService.getCertificateEntity(SecuredUUID.fromString(certificateUuid));
+        checkNewStatus(oldCertificate.getStatus());
         extendedAttributeService.validateLegacyConnector(raProfile.getAuthorityInstanceReference().getConnector());
         logger.debug("Rekeying Certificate: ", oldCertificate.toString());
         CertificateRenewRequestDto caRequest = new CertificateRenewRequestDto();
@@ -485,6 +487,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
 
         Certificate certificate = certificateService.getCertificateEntity(SecuredUUID.fromString(certificateUuid));
+        checkNewStatus(certificate.getStatus());
         extendedAttributeService.validateLegacyConnector(raProfile.getAuthorityInstanceReference().getConnector());
         logger.debug("Revoking Certificate: ", certificate.toString());
 
@@ -783,6 +786,15 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             throw new CertificateException(e);
         }
         return Map.of("csr", pkcs10, "attributes", merged);
+    }
+
+
+    private void checkNewStatus(CertificateStatus status) {
+        if(status.equals(CertificateStatus.NEW)) {
+            throw new ValidationException(
+                    ValidationError.create("Cannot perform operation on certificate with status NEW")
+            );
+        }
     }
 
 }

--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -16,6 +16,7 @@ import com.czertainly.api.model.core.audit.ObjectType;
 import com.czertainly.api.model.core.audit.OperationType;
 import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.api.model.core.authority.RevocationReason;
+import com.czertainly.api.model.core.certificate.CertificateDetailDto;
 import com.czertainly.api.model.core.certificate.CertificateEvent;
 import com.czertainly.api.model.core.certificate.CertificateEventStatus;
 import com.czertainly.api.model.core.certificate.CertificateStatus;
@@ -50,7 +51,9 @@ import org.springframework.stereotype.Service;
 
 import javax.security.auth.x500.X500Principal;
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
@@ -153,6 +156,17 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     }
 
     @Override
+    @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.CREATE)
+    public CertificateDetailDto createCsr(ClientCertificateRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException {
+        Map<String, Object> csrMap = generateCsr(request.getPkcs10(), request.getCsrAttributes(), request.getKeyUuid(), request.getTokenProfileUuid(), request.getSignatureAttributes());
+        String pkcs10 = (String) csrMap.get("csr");
+        List<DataAttribute> merged = (List<DataAttribute>) csrMap.get("merged");
+        Certificate csr = certificateService.createCsr(pkcs10, request.getSignatureAttributes(), merged, request.getKeyUuid());
+        certificateEventHistoryService.addEventHistory(CertificateEvent.CREATE_CSR, CertificateEventStatus.SUCCESS, "CSR created with the provided parameters", "", csr);
+        return csr.mapToDto();
+    }
+
+    @Override
     @AuditLogged(originator = ObjectType.CLIENT, affected = ObjectType.END_ENTITY_CERTIFICATE, operation = OperationType.ISSUE)
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public ClientCertificateDataResponseDto issueCertificate(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, ClientCertificateSignRequestDto request) throws ConnectorException, AlreadyExistException, CertificateException, NoSuchAlgorithmException {
@@ -161,49 +175,33 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
 
         extendedAttributeService.validateLegacyConnector(raProfile.getAuthorityInstanceReference().getConnector());
-
-        CertificateSignRequestDto caRequest = new CertificateSignRequestDto();
-        // the CSR should be properly converted to ensure consistent Base64-encoded format
+        Certificate certificate;
         String pkcs10;
-        String csr;
-        List<DataAttribute> merged = null;
+        CertificateDataResponseDto caResponse;
+        if(request.getUuid() != null) {
+            Certificate csrCertificate = certificateService.getCertificateEntity(SecuredUUID.fromUUID(request.getUuid()));
+            pkcs10 = csrCertificate.getCsr();
+            caResponse = issueCertificate(pkcs10, request.getAttributes(), raProfile);
+            certificate = certificateService.updateCsrToCertificate(csrCertificate.getUuid(), caResponse.getCertificateData(), caResponse.getMeta());
 
-        if (request.getPkcs10() != null && !request.getPkcs10().isEmpty()) {
-            csr = request.getPkcs10();
         } else {
-            merged = AttributeDefinitionUtils.mergeAttributes(CsrAttributes.csrAttributes(), request.getCsrAttributes());
-            AttributeDefinitionUtils.validateAttributes(CsrAttributes.csrAttributes(), request.getCsrAttributes());
-            csr = generateCsr(
+            // the CSR should be properly converted to ensure consistent Base64-encoded format
+            Map<String, Object> csrMap = generateCsr(request.getPkcs10(), request.getCsrAttributes(), request.getKeyUuid(), request.getTokenProfileUuid(), request.getSignatureAttributes());
+            pkcs10 = (String) csrMap.get("csr");
+            List<DataAttribute> merged = (List<DataAttribute>) csrMap.get("merged");
+            if (!isProtocolUser())
+                attributeService.validateCustomAttributes(request.getCustomAttributes(), Resource.CERTIFICATE);
+            caResponse = issueCertificate(pkcs10, request.getAttributes(), raProfile);
+            //Certificate certificate = certificateService.checkCreateCertificate(caResponse.getCertificateData());
+            certificate = certificateService.checkCreateCertificateWithMeta(
+                    caResponse.getCertificateData(),
+                    caResponse.getMeta(),
+                    pkcs10,
                     request.getKeyUuid(),
-                    request.getTokenProfileUuid(),
-                    CsrUtil.buildSubject(request.getCsrAttributes()),
+                    merged,
                     request.getSignatureAttributes()
             );
         }
-        try {
-            pkcs10 = Base64.getEncoder().encodeToString(parseCsrToJcaObject(csr).getEncoded());
-        } catch (IOException e) {
-            logger.debug("Failed to parse CSR: " + e);
-            throw new CertificateException(e);
-        }
-        caRequest.setPkcs10(pkcs10);
-        caRequest.setAttributes(request.getAttributes());
-        caRequest.setRaProfileAttributes(AttributeDefinitionUtils.getClientAttributes(raProfile.mapToDto().getAttributes()));
-        if (!isAcmeUser()) attributeService.validateCustomAttributes(request.getCustomAttributes(), Resource.CERTIFICATE);
-        CertificateDataResponseDto caResponse = certificateApiClient.issueCertificate(
-                raProfile.getAuthorityInstanceReference().getConnector().mapToDto(),
-                raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(),
-                caRequest);
-
-        //Certificate certificate = certificateService.checkCreateCertificate(caResponse.getCertificateData());
-        Certificate certificate = certificateService.checkCreateCertificateWithMeta(
-                caResponse.getCertificateData(),
-                caResponse.getMeta(),
-                pkcs10,
-                request.getKeyUuid(),
-                merged,
-                request.getSignatureAttributes()
-        );
 
         //Create Custom Attributes
         attributeService.createAttributeContent(certificate.getUuid(), request.getCustomAttributes(), Resource.CERTIFICATE);
@@ -227,6 +225,17 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         response.setCertificateData(caResponse.getCertificateData());
         response.setUuid(certificate.getUuid().toString());
         return response;
+    }
+
+    private CertificateDataResponseDto issueCertificate(String pkcs10, List<RequestAttributeDto> raProfileAttributes, RaProfile raProfile) throws ConnectorException {
+        CertificateSignRequestDto caRequest = new CertificateSignRequestDto();
+        caRequest.setPkcs10(pkcs10);
+        caRequest.setAttributes(raProfileAttributes);
+        caRequest.setRaProfileAttributes(AttributeDefinitionUtils.getClientAttributes(raProfile.mapToDto().getAttributes()));
+        return certificateApiClient.issueCertificate(
+                raProfile.getAuthorityInstanceReference().getConnector().mapToDto(),
+                raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(),
+                caRequest);
     }
 
     @Override
@@ -741,13 +750,39 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         }
     }
 
-    private boolean isAcmeUser() {
+    private boolean isProtocolUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication.getPrincipal() instanceof String
-                && "ACME_USER".equals(authentication.getPrincipal())) {
+                && ("acme".equals(authentication.getPrincipal())) || "scep".equals(authentication.getPrincipal())) {
             return true;
         }
         return false;
+    }
+
+    private Map<String, Object> generateCsr(String uploadedCsr, List<RequestAttributeDto> csrAttributes, UUID keyUUid, UUID tokenProfileUuid, List<RequestAttributeDto> signatureAttributes) throws NotFoundException, CertificateException {
+        String pkcs10;
+        String csr;
+        List<DataAttribute> merged = List.of();
+
+        if (uploadedCsr != null && !uploadedCsr.isEmpty()) {
+            csr = uploadedCsr;
+        } else {
+            merged = AttributeDefinitionUtils.mergeAttributes(CsrAttributes.csrAttributes(), csrAttributes);
+            AttributeDefinitionUtils.validateAttributes(CsrAttributes.csrAttributes(), csrAttributes);
+            csr = generateCsr(
+                    keyUUid,
+                    tokenProfileUuid,
+                    CsrUtil.buildSubject(csrAttributes),
+                    signatureAttributes
+            );
+        }
+        try {
+            pkcs10 = Base64.getEncoder().encodeToString(parseCsrToJcaObject(csr).getEncoded());
+        } catch (IOException e) {
+            logger.debug("Failed to parse CSR: " + e);
+            throw new CertificateException(e);
+        }
+        return Map.of("csr", pkcs10, "attributes", merged);
     }
 
 }

--- a/src/main/java/com/czertainly/core/util/CertificateUtil.java
+++ b/src/main/java/com/czertainly/core/util/CertificateUtil.java
@@ -16,6 +16,7 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.DefaultAlgorithmNameFinder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.slf4j.Logger;
@@ -292,7 +293,8 @@ public class CertificateUtil {
         }
 
         modal.setPublicKeyAlgorithm(getAlgorithmFromProviderName(certificate.getPublicKey().getAlgorithm()));
-        modal.setSignatureAlgorithm(certificate.getSignatureAlgorithm().getAlgorithm().toString().replace("WITH", "with"));
+        DefaultAlgorithmNameFinder algFinder = new DefaultAlgorithmNameFinder();
+        modal.setSignatureAlgorithm(algFinder.getAlgorithmName(certificate.getSignatureAlgorithm()).replace("WITH", "with"));
         modal.setStatus(CertificateStatus.NEW);
         modal.setKeySize(KeySizeUtil.getKeyLength(certificate.getPublicKey()));
         modal.setSubjectAlternativeNames(MetaDefinitions.serialize(getSAN(certificate)));

--- a/src/main/java/com/czertainly/core/util/CertificateUtil.java
+++ b/src/main/java/com/czertainly/core/util/CertificateUtil.java
@@ -8,6 +8,12 @@ import com.czertainly.api.model.core.certificate.CertificateStatus;
 import com.czertainly.api.model.core.certificate.CertificateType;
 import com.czertainly.core.dao.entity.Certificate;
 import jakarta.xml.bind.DatatypeConverter;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
@@ -22,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
@@ -157,6 +164,44 @@ public class CertificateUtil {
         return sans;
     }
 
+
+    private static Map<String, Object> getSAN(JcaPKCS10CertificationRequest csr) {
+
+        Map<String, Object> sans = new HashMap<>();
+        sans.put("otherName", new ArrayList<>());
+        sans.put("rfc822Name", new ArrayList<>());
+        sans.put("dNSName", new ArrayList<>());
+        sans.put("x400Address", new ArrayList<>());
+        sans.put("directoryName", new ArrayList<>());
+        sans.put("ediPartyName", new ArrayList<>());
+        sans.put("uniformResourceIdentifier", new ArrayList<>());
+        sans.put("iPAddress", new ArrayList<>());
+        sans.put("registeredID", new ArrayList<>());
+
+        Attribute[] certAttributes = csr.getAttributes();
+        for (Attribute attribute : certAttributes) {
+            if (attribute.getAttrType().equals(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest)) {
+                Extensions extensions = Extensions.getInstance(attribute.getAttrValues().getObjectAt(0));
+                GeneralNames gns = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+                GeneralName[] names = gns.getNames();
+                for (GeneralName name : names) {
+                    switch (name.getTagNo()){
+                        case GeneralName.dNSName: ((ArrayList<String>) sans.get("dNSName")).add(name.getName().toString());
+                        case GeneralName.iPAddress: ((ArrayList<String>) sans.get("iPAddress")).add(name.getName().toString());
+                        case GeneralName.otherName: ((ArrayList<String>) sans.get("otherName")).add(name.getName().toString());
+                        case GeneralName.directoryName: ((ArrayList<String>) sans.get("directoryName")).add(name.getName().toString());
+                        case GeneralName.registeredID: ((ArrayList<String>) sans.get("registeredID")).add(name.getName().toString());
+                        case GeneralName.x400Address: ((ArrayList<String>) sans.get("x400Address")).add(name.getName().toString());
+                        case GeneralName.uniformResourceIdentifier: ((ArrayList<String>) sans.get("uniformResourceIdentifier")).add(name.getName().toString());
+                        case GeneralName.ediPartyName: ((ArrayList<String>) sans.get("ediPartyName")).add(name.getName().toString());
+                        case GeneralName.rfc822Name: ((ArrayList<String>) sans.get("rfc822Name")).add(name.getName().toString());
+                    }
+                }
+            }
+        }
+        return sans;
+    }
+
     public static X509Certificate parseCertificate(String cert) throws CertificateException {
         cert = cert.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "")
                 .replace("\r", "").replace("\n", "");
@@ -229,6 +274,33 @@ public class CertificateUtil {
 
         return modal;
     }
+
+
+    public static Certificate prepareCsrObject(Certificate modal, JcaPKCS10CertificationRequest certificate) throws NoSuchAlgorithmException, InvalidKeyException {
+        setSubjectDNParams(modal, certificate.getSubject().toString());
+        if (certificate.getPublicKey() == null) {
+            throw new ValidationException(
+                    ValidationError.create(
+                            "Invalid Certificate. Public Key is missing"
+                    )
+            );
+        }
+        try {
+            modal.setPublicKeyFingerprint(getThumbprint(Base64.getEncoder().encodeToString(certificate.getPublicKey().getEncoded()).getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            logger.error("Failed to calculate the thumbprint of the certificate");
+        }
+
+        modal.setPublicKeyAlgorithm(getAlgorithmFromProviderName(certificate.getPublicKey().getAlgorithm()));
+        modal.setSignatureAlgorithm(certificate.getSignatureAlgorithm().getAlgorithm().toString().replace("WITH", "with"));
+        modal.setStatus(CertificateStatus.NEW);
+        modal.setKeySize(KeySizeUtil.getKeyLength(certificate.getPublicKey()));
+        modal.setSubjectAlternativeNames(MetaDefinitions.serialize(getSAN(certificate)));
+        return modal;
+    }
+
+
+
 
     private static void setIssuerDNParams(Certificate modal, String issuerDN) {
         modal.setIssuerDn(issuerDN);

--- a/src/main/resources/db/migration/V202303200000__certificate_new_status.sql
+++ b/src/main/resources/db/migration/V202303200000__certificate_new_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE certificate ALTER COLUMN serial_number DROP NOT NULL;
+ALTER TABLE certificate ALTER COLUMN not_before DROP NOT NULL;
+ALTER TABLE certificate ALTER COLUMN not_after DROP NOT NULL;
+ALTER TABLE certificate ALTER COLUMN issuer_dn DROP NOT NULL;
+ALTER TABLE certificate ALTER COLUMN fingerprint DROP NOT NULL;

--- a/src/test/java/com/czertainly/core/service/CertValidationServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CertValidationServiceTest.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.service;
 
 import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.core.certificate.CertificateStatus;
 import com.czertainly.core.dao.entity.Certificate;
 import com.czertainly.core.dao.entity.CertificateContent;
 import com.czertainly.core.dao.repository.CertificateContentRepository;
@@ -23,6 +24,7 @@ import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -60,6 +62,9 @@ public class CertValidationServiceTest extends BaseSpringBootTest {
         certificate.setSubjectDn("testCertificate");
         certificate.setIssuerDn("testCertificate");
         certificate.setSerialNumber("123456789");
+        certificate.setStatus(CertificateStatus.VALID);
+        certificate.setNotBefore(new Date());
+        certificate.setNotAfter(new Date());
         certificate.setCertificateContent(certificateContent);
         certificate = certificateRepository.save(certificate);
     }

--- a/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
@@ -69,6 +69,7 @@ public class CertificateServiceTest extends BaseSpringBootTest {
         certificate.setSubjectDn("testCertificate");
         certificate.setIssuerDn("testCertificate");
         certificate.setSerialNumber("123456789");
+        certificate.setStatus(CertificateStatus.VALID);
         certificate.setCertificateContent(certificateContent);
         certificate.setCertificateContentId(certificateContent.getId());
         certificate = certificateRepository.save(certificate);

--- a/src/test/java/com/czertainly/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/czertainly/core/service/ClientOperationServiceV2Test.java
@@ -4,6 +4,7 @@ import com.czertainly.api.exception.*;
 import com.czertainly.api.model.common.NameAndIdDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.ObjectAttributeContent;
+import com.czertainly.api.model.core.certificate.CertificateStatus;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.czertainly.api.model.core.v2.ClientCertificateRenewRequestDto;
@@ -126,6 +127,7 @@ public class ClientOperationServiceV2Test extends BaseSpringBootTest {
         certificate.setIssuerDn("testCertificate");
         certificate.setSerialNumber("123456789");
         certificate.setCertificateContent(certificateContent);
+        certificate.setStatus(CertificateStatus.VALID);
         certificate.setCertificateContentId(certificateContent.getId());
         certificate = certificateRepository.save(certificate);
 


### PR DESCRIPTION
This PR Contains the changes for the following:

1. Include a new API to create the CSR without issuing the certificate
2. Add API to issue the certificate from the saved CSR
3. Add DTO for the above operations
closes #336 