### PR TITLE
Fix key item reference in the metadata

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
@@ -981,7 +981,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyService {
         );
         metadataService.createMetadata(
                 connectorUuid,
-                UUID.fromString(referenceUuid),
+                UUID.fromString(content.getUuid().toString()),
                 cryptographicKey.getUuid(),
                 referenceName,
                 keyData.getMetadata(),

--- a/src/main/resources/db/migration/V202303241800__cryptographic_key_reference.sql
+++ b/src/main/resources/db/migration/V202303241800__cryptographic_key_reference.sql
@@ -1,0 +1,14 @@
+DELETE FROM attribute_content_2_object a
+WHERE a.object_type = 'CRYPTOGRAPHIC_KEY'
+AND  a.source_object_type = 'CRYPTOGRAPHIC_KEY'
+AND a.object_uuid NOT IN (SELECT key_reference_uuid FROM cryptographic_key_item);
+
+with ct2a AS (SELECT a.object_uuid, c.key_reference_uuid, c.uuid
+ FROM attribute_content_2_object a
+ JOIN cryptographic_key_item c
+ ON a.object_uuid = c.key_reference_uuid
+ WHERE a.object_type = 'CRYPTOGRAPHIC_KEY'
+ AND  a.source_object_type = 'CRYPTOGRAPHIC_KEY')
+ UPDATE attribute_content_2_object AS a1
+ SET object_uuid = ct2a.uuid FROM ct2a
+ WHERE a1.object_uuid = ct2a.key_reference_uuid;

--- a/src/main/resources/db/migration/V202303241800__cryptographic_key_reference.sql
+++ b/src/main/resources/db/migration/V202303241800__cryptographic_key_reference.sql
@@ -12,3 +12,4 @@ with ct2a AS (SELECT a.object_uuid, c.key_reference_uuid, c.uuid
  UPDATE attribute_content_2_object AS a1
  SET object_uuid = ct2a.uuid FROM ct2a
  WHERE a1.object_uuid = ct2a.key_reference_uuid;
+ 


### PR DESCRIPTION
This PR contains the fix for the following:

1. Fix the reference of the key item in the attribute content to object mapping to be the uuid instead of the reference uuid form connector