### PR TITLE
Fix notification instance mapped attributes DTO creation

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/NotificationInstanceReference.java
+++ b/src/main/java/com/czertainly/core/dao/entity/NotificationInstanceReference.java
@@ -118,10 +118,6 @@ public class NotificationInstanceReference extends UniquelyIdentified implements
         if (this.connector != null) {
             dto.setConnectorUuid(this.connector.getUuid().toString());
         }
-        dto.setAttributeMappings(this.getMappedAttributes()
-                .stream()
-                .map(NotificationInstanceMappedAttributes::mapToDto)
-                .collect(Collectors.toList()));
         return dto;
     }
 


### PR DESCRIPTION
attributes and mapped attributes of notification instance is in response only in GET detail of notification instance