### PR TITLE
Fix ACME finalize order to reflect async issuance process

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/acme/AcmeOrder.java
+++ b/src/main/java/com/czertainly/core/dao/entity/acme/AcmeOrder.java
@@ -71,7 +71,7 @@ public class AcmeOrder extends UniquelyIdentifiedAndAudited implements Serializa
         order.setAuthorizations(authorizations.stream().map(AcmeAuthorization::getUrl).collect(Collectors.toList()));
         order.setFinalize(getFinalizeUrl());
         if(certificateId != null){
-            order.setCertificate(getCertificateUrl());
+            order.setCertificate(getCertificateUrl()); // should we include URL of certificate if order is still in PROCESSING state?
         }
         order.setStatus(status);
         order.setExpires(AcmeCommonHelper.getStringFromDate(expires));

--- a/src/main/java/com/czertainly/core/dao/entity/acme/AcmeOrder.java
+++ b/src/main/java/com/czertainly/core/dao/entity/acme/AcmeOrder.java
@@ -70,10 +70,10 @@ public class AcmeOrder extends UniquelyIdentifiedAndAudited implements Serializa
         Order order = new Order();
         order.setAuthorizations(authorizations.stream().map(AcmeAuthorization::getUrl).collect(Collectors.toList()));
         order.setFinalize(getFinalizeUrl());
-        if(certificateId != null){
-            order.setCertificate(getCertificateUrl()); // should we include URL of certificate if order is still in PROCESSING state?
-        }
         order.setStatus(status);
+        if (status.equals(OrderStatus.VALID)) {
+            order.setCertificate(getCertificateUrl());
+        }
         order.setExpires(AcmeCommonHelper.getStringFromDate(expires));
         order.setNotAfter(AcmeCommonHelper.getStringFromDate(notAfter));
         order.setNotBefore(AcmeCommonHelper.getStringFromDate(notBefore));

--- a/src/main/java/com/czertainly/core/service/acme/impl/AcmeRaProfileServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/acme/impl/AcmeRaProfileServiceImpl.java
@@ -119,9 +119,7 @@ public class AcmeRaProfileServiceImpl implements AcmeRaProfileService {
     public ResponseEntity<Order> finalizeOrder(String raProfileName, String orderId, String jwsBody) throws AcmeProblemDocumentException, ConnectorException {
         extendedAcmeHelperService.initialize(jwsBody);
         AcmeOrder order = extendedAcmeHelperService.checkOrderForFinalize(orderId);
-        logger.debug("Finalizing the Order with ID: {}", orderId);
         extendedAcmeHelperService.finalizeOrder(order);
-        order.setStatus(OrderStatus.PROCESSING);
         return ResponseEntity
                 .ok()
                 .location(URI.create(order.getUrl()))
@@ -132,9 +130,7 @@ public class AcmeRaProfileServiceImpl implements AcmeRaProfileService {
 
     @Override
     public ResponseEntity<Order> getOrder(String raProfileName, String orderId) throws NotFoundException, AcmeProblemDocumentException {
-        logger.info("Get Order details with ID: {}", orderId);
         AcmeOrder order = extendedAcmeHelperService.getAcmeOrderEntity(orderId);
-        logger.debug("Order: {}", order);
         extendedAcmeHelperService.updateOrderStatusByExpiry(order);
         if (order.getStatus().equals(OrderStatus.INVALID)) {
             logger.error("Order status is invalid: {}", order);

--- a/src/main/java/com/czertainly/core/service/acme/impl/ExtendedAcmeHelperService.java
+++ b/src/main/java/com/czertainly/core/service/acme/impl/ExtendedAcmeHelperService.java
@@ -547,8 +547,8 @@ public class ExtendedAcmeHelperService {
         } catch (NotFoundException e) {
             throw new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, new ProblemDocument("orderNotFound", "Order Not Found", "The given Order is not found"));
         }
-        if (order.getStatus().equals(OrderStatus.INVALID) || order.getStatus().equals(OrderStatus.PENDING)) {
-            logger.error("Order status: {}", order.getStatus());
+        if (!order.getStatus().equals(OrderStatus.READY)) { // A request to finalize an order will result in error if the order is not in the "ready" state
+            logger.error("Cannot finalize Order that is not ready.");
             throw new AcmeProblemDocumentException(HttpStatus.FORBIDDEN, Problem.ORDER_NOT_READY);
         }
         return order;

--- a/src/main/java/com/czertainly/core/service/acme/impl/ExtendedAcmeHelperService.java
+++ b/src/main/java/com/czertainly/core/service/acme/impl/ExtendedAcmeHelperService.java
@@ -441,7 +441,18 @@ public class ExtendedAcmeHelperService {
     protected AcmeOrder getAcmeOrderEntity(String orderId) throws AcmeProblemDocumentException {
         logger.info("Gathering ACME Order details with ID: {}", orderId);
         AcmeOrder acmeOrder = acmeOrderRepository.findByOrderId(orderId).orElseThrow(() -> new AcmeProblemDocumentException(HttpStatus.BAD_REQUEST, new ProblemDocument("orderNotFound", "Order Not Found", "Specified ACME Order not found")));
-        logger.debug("Order: {}", acmeOrder.toString());
+        logger.debug("Order: {}", acmeOrder);
+
+        // check for status if certificate reference is set
+        if(acmeOrder.getCertificateReference() != null) {
+            OrderStatus newStatus = checkOrderStatusByCertificate(acmeOrder.getCertificateReference());
+            if (!newStatus.equals(acmeOrder.getStatus())) {
+                logger.info("ACME Order status changed from {} to {}.", acmeOrder.getStatus(), newStatus);
+                acmeOrder.setStatus(newStatus);
+                acmeOrderRepository.save(acmeOrder);
+            }
+        }
+
         return acmeOrder;
     }
 
@@ -460,8 +471,7 @@ public class ExtendedAcmeHelperService {
 
     protected ByteArrayResource getCertificateResource(String certificateId) throws NotFoundException, CertificateException {
         AcmeOrder order = acmeOrderRepository.findByCertificateId(certificateId).orElseThrow(() -> new NotFoundException(Order.class, certificateId));
-        Certificate certificate = order.getCertificateReference();
-        CertificateChainResponseDto certificateChainResponse = certificateService.getCertificateChain(certificate.getSecuredUuid(), true);
+        CertificateChainResponseDto certificateChainResponse = certificateService.getCertificateChain(SecuredUUID.fromUUID(order.getCertificateReferenceUuid()), true);
         String chainString = frameCertChainString(certificateChainResponse.getCertificates());
         return new ByteArrayResource(chainString.getBytes(StandardCharsets.UTF_8));
     }
@@ -546,8 +556,9 @@ public class ExtendedAcmeHelperService {
 
     @Async("threadPoolTaskExecutor")
     public void finalizeOrder(AcmeOrder order) throws AcmeProblemDocumentException {
+        logger.info("Finalizing Order with ID: {}", order.getOrderId());
         CertificateFinalizeRequest request = AcmeJsonProcessor.getPayloadAsRequestObject(getJwsObject(), CertificateFinalizeRequest.class);
-        logger.debug("Finalize Order: {}", request.toString());
+        logger.debug("Finalize Order request: {}", request);
         JcaPKCS10CertificationRequest p10Object;
         String decodedCsr = "";
         try {
@@ -560,7 +571,7 @@ public class ExtendedAcmeHelperService {
         }
         decodedCsr = decodedCsr.replace("-----BEGIN CERTIFICATE REQUEST-----", "").replace("-----BEGIN NEW CERTIFICATE REQUEST-----", "")
                 .replace("\r", "").replace("\n", "").replace("-----END CERTIFICATE REQUEST-----", "").replace("-----END NEW CERTIFICATE REQUEST-----", "");
-        logger.info("Initiating issue Certificate for Order: {}", order);
+        logger.info("Initiating issue Certificate for Order with ID: {}", order.getOrderId());
         ClientCertificateSignRequestDto certificateSignRequestDto = new ClientCertificateSignRequestDto();
         certificateSignRequestDto.setAttributes(getClientOperationAttributes(false, order.getAcmeAccount()));
         certificateSignRequestDto.setPkcs10(decodedCsr);
@@ -580,20 +591,30 @@ public class ExtendedAcmeHelperService {
     }
 
     private void createCert(AcmeOrder order, ClientCertificateSignRequestDto certificateSignRequestDto) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Initiating issue Certificate for the Order: {} and certificate signing request: {}", order.toString(), certificateSignRequestDto.toString());
+        // check if certificate is not already requested (prevent calling finalize multiple times issuing more certificates)
+        // not sure if it is necessary
+        if (order.getCertificateReference() == null) {
+            try {
+                // keep state as PROCESSING since issuing is async process
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Requesting Certificate for the Order: {} and certificate signing request: {}", order, certificateSignRequestDto);
+                }
+                ClientCertificateDataResponseDto certificateOutput = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()), order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateSignRequestDto);
+                order.setCertificateId(AcmeRandomGeneratorAndValidator.generateRandomId());
+                order.setCertificateReference(certificateService.getCertificateEntity(SecuredUUID.fromString(certificateOutput.getUuid())));
+            } catch (Exception e) {
+                logger.error("Issue Certificate failed. Exception: {}", e.getMessage());
+                order.setStatus(OrderStatus.INVALID);
+            }
+            acmeOrderRepository.save(order);
+        } else {
+            OrderStatus newStatus = checkOrderStatusByCertificate(order.getCertificateReference());
+            logger.debug("Calling finalize of Order but certificate is already requested. Current status: {}", newStatus);
+            if(!newStatus.equals(order.getStatus())) {
+                order.setStatus(newStatus);
+                acmeOrderRepository.save(order);
+            }
         }
-        try {
-            // TODO should be by approvals ?
-            ClientCertificateDataResponseDto certificateOutput = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()), order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateSignRequestDto);
-            order.setCertificateId(AcmeRandomGeneratorAndValidator.generateRandomId());
-            order.setCertificateReference(certificateService.getCertificateEntity(SecuredUUID.fromString(certificateOutput.getUuid())));
-            order.setStatus(OrderStatus.VALID);
-        } catch (Exception e) {
-            logger.error("Issue Certificate failed. Exception: {}", e.getMessage());
-            order.setStatus(OrderStatus.INVALID);
-        }
-        acmeOrderRepository.save(order);
     }
 
     public ResponseEntity<List<Order>> listOrders(String accountId) throws AcmeProblemDocumentException {
@@ -1078,23 +1099,32 @@ public class ExtendedAcmeHelperService {
     }
 
     private List<RequestAttributeDto> getClientOperationAttributes(boolean isRevoke, AcmeAccount acmeAccount) {
-        if(acmeAccount == null) {
+        if (acmeAccount == null) {
             return List.of();
         }
         String attributes;
         if (ServletUriComponentsBuilder.fromCurrentRequestUri().build().toUriString().contains("/raProfile/")) {
-            if(isRevoke) {
+            if (isRevoke) {
                 attributes = acmeAccount.getRaProfile().getProtocolAttribute().getAcmeRevokeCertificateAttributes();
             } else {
                 attributes = acmeAccount.getRaProfile().getProtocolAttribute().getAcmeIssueCertificateAttributes();
             }
         } else {
-            if(isRevoke) {
+            if (isRevoke) {
                 attributes = acmeAccount.getAcmeProfile().getRevokeCertificateAttributes();
             } else {
                 attributes = acmeAccount.getAcmeProfile().getIssueCertificateAttributes();
             }
         }
         return AttributeDefinitionUtils.getClientAttributes(AttributeDefinitionUtils.deserialize(attributes, DataAttribute.class));
+    }
+
+    private OrderStatus checkOrderStatusByCertificate(Certificate certificate) {
+        if (certificate.getState().equals(CertificateState.ISSUED)) return OrderStatus.VALID;
+        if (certificate.getState().equals(CertificateState.REQUESTED)
+                || certificate.getState().equals(CertificateState.PENDING_APPROVAL)
+                || certificate.getState().equals(CertificateState.PENDING_ISSUE)) return OrderStatus.PROCESSING;
+
+        return OrderStatus.INVALID;
     }
 }

--- a/src/test/java/com/czertainly/core/service/AcmeRaProfileServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/AcmeRaProfileServiceTest.java
@@ -246,8 +246,9 @@ public class AcmeRaProfileServiceTest extends BaseSpringBootTest {
                 "  \"signature\": \"0xnnC2Stx0IJyDvEZ3sDda_50oEocMGZkQvOxniXp8cbk17fpKYS9sRgMqDTeC8uaUWtv7YIRGoCHQvTYs40_Q3bdGmJGtN-ltZte3LM5oJARQPwgB8NIVzXkE6axd_8So1Xsau5yVi23dHO_y0MIYQzUYFpyn_30bCkTfNdiOIrX55qb8EX0E5OwPUrcUXeVtXAkpxLLMew2ZcQF1pHYjTNFQ1ZXtlO9xcTWZikLq5Eg_3FRWuh0ZxqsVw6-8QtYM2W44Zna2ZGbIAm2jveVTEM2O-ZAvYxFxYmNdUR9aNVPpme76OC5v3rjVsnJaBtDjpkJ9ub7EbOk9kvG1oD6w\",\n" +
                 "  \"payload\": \"ewogICJjc3IiOiAiTUlJQ2RqQ0NBVjRDQVFJd0FEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUxlSnZ4N0pXYnd6b2JXTDc0S3lIejBGalBxdDBSNWlPYU94aVlxcGZNWS1aVmhNQmtTMEZxbkNCUXpNbjVCa0h1a2R4N0hzSU1rSi1zTTAxSFZISmFScGdwZjF6ZVR5UlFqWTdFU0Rpa1JMXzFFa3hpNlNnZjV1bnpCMzVhUDJFQnhpQWFvbUc2MTBIanBxU2ZHdE96RWYxMmh5NGprY0M0NDZUVDhuRTlkbTZDQmY3WEFvcTl2WHhYUmpuQWdka3I2MnlJemFuWGVkRHdkY055azVFaWlSV1FYd1ctTDVQZXg1ODA4aXAyZ21FNUFsNVNQVWl2OGVEQ3EwMlFWREo4TG40VVBZa3hMMWI2Uk1sZkVnS0xzR0VaWDBlLUZDMHdfZmlCTjQ4enJ2SHhxTTJmZFU3QWU4cFJEd1VPQ2xZT3hEa3J2RHY2MFJHaWtMbFFaNDVGY0NBd0VBQWFBeE1DOEdDU3FHU0liM0RRRUpEakVpTUNBd0hnWURWUjBSQkJjd0ZZSVRaR1ZpYVdGdU1UQXVZV050WlM1c2IyTmhiREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSGxPMFp1UHVZRXRwbFUwZ0VVajg4WWkxTVdrckVseDBKb1RrN3FvblJzdWZ1X1kyUF91LVJya1dPek0zVkowOGxOejkwTF9tbmM4Tk9PTk1sX1dsWVdCeXdiVU1zR2FyNFlfMXgweVNPRWRwNWZnODdyeFkxYjJqYlNMN3RQZTRPVjd5QWViZENFenpYWEJpM0F5OU5vSkFod05PTmp5UnA5MnZxVDUtTVdNWFF5WnZkY1VNTTM4bDZhTmM5am9mM0VsdU5iZ083bldTbGU2TVFKSnZsRVl3WHg3WlB2dmd4TWZyUmEtWWNfYVdTN3cyNU1TQU9ES0t3dklpdkduNXFfb3dmZDVBb3pZcDBweW1pTExidkFXaFlWV0xfLWJHdkoxM3hweWZOUG5HSklkd2NZOHpnaWtZUHlCZmJSbVB5S0pMUEk0UW5XejhHc1dHaWFVZ2pBIgp9\"\n" +
                 "}";
-        ResponseEntity<Order> order = acmeService.finalizeOrder("sameName", "order123", requestJson);
-        Assertions.assertNotNull(order);
+        // ResponseEntity<Order> order = acmeService.finalizeOrder("sameName", "order123", requestJson);
+        // Assertions.assertNotNull(order);
+        Assertions.assertThrows(AcmeProblemDocumentException.class, () -> acmeService.finalizeOrder("sameName", "order123", requestJson));
     }
 
     @Test

--- a/src/test/java/com/czertainly/core/service/AcmeServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/AcmeServiceTest.java
@@ -249,8 +249,9 @@ public class AcmeServiceTest extends BaseSpringBootTest {
                 "  \"signature\": \"0xnnC2Stx0IJyDvEZ3sDda_50oEocMGZkQvOxniXp8cbk17fpKYS9sRgMqDTeC8uaUWtv7YIRGoCHQvTYs40_Q3bdGmJGtN-ltZte3LM5oJARQPwgB8NIVzXkE6axd_8So1Xsau5yVi23dHO_y0MIYQzUYFpyn_30bCkTfNdiOIrX55qb8EX0E5OwPUrcUXeVtXAkpxLLMew2ZcQF1pHYjTNFQ1ZXtlO9xcTWZikLq5Eg_3FRWuh0ZxqsVw6-8QtYM2W44Zna2ZGbIAm2jveVTEM2O-ZAvYxFxYmNdUR9aNVPpme76OC5v3rjVsnJaBtDjpkJ9ub7EbOk9kvG1oD6w\",\n" +
                 "  \"payload\": \"ewogICJjc3IiOiAiTUlJQ2RqQ0NBVjRDQVFJd0FEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUxlSnZ4N0pXYnd6b2JXTDc0S3lIejBGalBxdDBSNWlPYU94aVlxcGZNWS1aVmhNQmtTMEZxbkNCUXpNbjVCa0h1a2R4N0hzSU1rSi1zTTAxSFZISmFScGdwZjF6ZVR5UlFqWTdFU0Rpa1JMXzFFa3hpNlNnZjV1bnpCMzVhUDJFQnhpQWFvbUc2MTBIanBxU2ZHdE96RWYxMmh5NGprY0M0NDZUVDhuRTlkbTZDQmY3WEFvcTl2WHhYUmpuQWdka3I2MnlJemFuWGVkRHdkY055azVFaWlSV1FYd1ctTDVQZXg1ODA4aXAyZ21FNUFsNVNQVWl2OGVEQ3EwMlFWREo4TG40VVBZa3hMMWI2Uk1sZkVnS0xzR0VaWDBlLUZDMHdfZmlCTjQ4enJ2SHhxTTJmZFU3QWU4cFJEd1VPQ2xZT3hEa3J2RHY2MFJHaWtMbFFaNDVGY0NBd0VBQWFBeE1DOEdDU3FHU0liM0RRRUpEakVpTUNBd0hnWURWUjBSQkJjd0ZZSVRaR1ZpYVdGdU1UQXVZV050WlM1c2IyTmhiREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSGxPMFp1UHVZRXRwbFUwZ0VVajg4WWkxTVdrckVseDBKb1RrN3FvblJzdWZ1X1kyUF91LVJya1dPek0zVkowOGxOejkwTF9tbmM4Tk9PTk1sX1dsWVdCeXdiVU1zR2FyNFlfMXgweVNPRWRwNWZnODdyeFkxYjJqYlNMN3RQZTRPVjd5QWViZENFenpYWEJpM0F5OU5vSkFod05PTmp5UnA5MnZxVDUtTVdNWFF5WnZkY1VNTTM4bDZhTmM5am9mM0VsdU5iZ083bldTbGU2TVFKSnZsRVl3WHg3WlB2dmd4TWZyUmEtWWNfYVdTN3cyNU1TQU9ES0t3dklpdkduNXFfb3dmZDVBb3pZcDBweW1pTExidkFXaFlWV0xfLWJHdkoxM3hweWZOUG5HSklkd2NZOHpnaWtZUHlCZmJSbVB5S0pMUEk0UW5XejhHc1dHaWFVZ2pBIgp9\"\n" +
                 "}";
-        ResponseEntity<Order> order = acmeService.finalizeOrder("sameName", "order123", requestJson);
-        Assertions.assertNotNull(order);
+        // ResponseEntity<Order> order = acmeService.finalizeOrder("sameName", "order123", requestJson);
+        // Assertions.assertNotNull(order);
+        Assertions.assertThrows(AcmeProblemDocumentException.class, () -> acmeService.finalizeOrder("sameName", "order123", requestJson));
     }
 
     @Test


### PR DESCRIPTION
Based on [ACME RFC8555](https://datatracker.ietf.org/doc/html/rfc8555#section-7.1).

At the end of the referred section is table that illustrates a typical sequence of requests required to establish a new account with the server, prove control of an identifier, issue a certificate, and fetch an updated certificate some time after issuance.

