### PR TITLE
Do not change validation status to revoked when certificate is revoked by user

### DIFF
--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -681,7 +681,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                     caRequest);
 
             certificate.setState(CertificateState.REVOKED);
-            certificate.setRevokeAttributes(AttributeDefinitionUtils.serialize(extendedAttributeService.mergeAndValidateIssueAttributes(raProfile, request.getAttributes())));
+            certificate.setRevokeAttributes(AttributeDefinitionUtils.serializeRequestAttributes(request.getAttributes()));
             certificateRepository.save(certificate);
             certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + caRequest.getReason().getLabel(), "");
         } catch (Exception e) {

--- a/src/test/java/com/czertainly/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/czertainly/core/service/ClientOperationServiceV2Test.java
@@ -255,6 +255,7 @@ public class ClientOperationServiceV2Test extends BaseSpringBootTest {
                 .willReturn(WireMock.okJson("true")));
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
+        request.setAttributes(List.of());
         clientOperationService.revokeCertificateAction(certificate.getUuid(), request, true);
     }
 


### PR DESCRIPTION
Let the certificate validation process take care of revocation status from CRL or OCSP